### PR TITLE
Feature: Best-effort enforcement of SRI gen execution order in vite plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "vite-plugin-sri-gen",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"description": "A Vite plugin to auto-generate Subresource Integrity (SRI) hashes.",
 	"type": "module",
 	"types": "./dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,11 +65,13 @@ export default function sri(options: SriPluginOptions = {}): Plugin & {
 	let sriByPathname: Record<string, string> = {};
 	let dynamicChunkFiles: Set<string> = new Set();
 
-	return {
+	const plugin = {
 		name: "vite-plugin-sri-gen",
 		enforce: "post",
 		// Only run during `vite build`
 		apply: "build",
+		order: "post",
+		sequential: true,
 
 		configResolved(config: ResolvedConfig): void {
 			// Fallback SSR detection from resolved config (may be a string or boolean)
@@ -108,9 +110,9 @@ export default function sri(options: SriPluginOptions = {}): Plugin & {
 			});
 		},
 
-		async generateBundle(_options: unknown, bundle: OutputBundle) {
+		async writeBundle(_options: unknown, bundle: OutputBundle) {
 			/**
-			 * Main entry point for bundle generation with SRI processing.
+			 * Main entry point for SRI processing after bundle write completion.
 			 * This function orchestrates the entire SRI generation workflow:
 			 * 1. Validates input parameters and initializes logging
 			 * 2. Builds integrity mappings for all processable assets
@@ -200,4 +202,6 @@ export default function sri(options: SriPluginOptions = {}): Plugin & {
 			return { code: injected + code, map: null };
 		},
 	} as any;
+
+	return plugin;
 }

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -231,7 +231,7 @@ describe("vite-plugin-sri-gen", () => {
 				"entry.js": { code: "console.log(1)" },
 			};
 
-			await plugin.generateBundle({}, bundle);
+			await plugin.writeBundle({}, bundle);
 			const out = String(bundle["index.html"].source);
 			expect(out).toContain('integrity="sha256-');
 			expect(out).toContain('crossorigin="anonymous"');
@@ -247,7 +247,7 @@ describe("vite-plugin-sri-gen", () => {
 				"a.js": { code: "console.log(1)" },
 			};
 
-			await plugin.generateBundle({}, bundle);
+			await plugin.writeBundle({}, bundle);
 			const out = String(bundle["index.html"].source);
 			expect(out).toContain('integrity="sha256-abc"');
 		});
@@ -262,7 +262,7 @@ describe("vite-plugin-sri-gen", () => {
 				build: { ssr: true },
 			} as any);
 			const bundle: any = { "entry.js": { code: "console.log(1)" } };
-			await plugin.generateBundle({}, bundle);
+			await plugin.writeBundle({}, bundle);
 			expect(spies.warn).toHaveBeenCalled();
 			cleanup();
 		});
@@ -279,7 +279,7 @@ describe("vite-plugin-sri-gen", () => {
 				"index.html": { type: "asset", source: badSource },
 				"entry.js": { code: "console.log(1)" },
 			};
-			await plugin.generateBundle({}, bundle);
+			await plugin.writeBundle({}, bundle);
 			expect(spies.warn).toHaveBeenCalled();
 			cleanup();
 		});
@@ -295,7 +295,7 @@ describe("vite-plugin-sri-gen", () => {
 				build: { ssr: false },
 			} as any);
 			const bundle: any = { "entry.js": { code: "console.log(1)" } };
-			await plugin.generateBundle({}, bundle);
+			await plugin.writeBundle({}, bundle);
 			expect(spies.warn).not.toHaveBeenCalled();
 			cleanup();
 		});
@@ -311,7 +311,7 @@ describe("vite-plugin-sri-gen", () => {
 				},
 				"a.js": { code: "console.log(1)" },
 			};
-			await plugin.generateBundle({}, bundle);
+			await plugin.writeBundle({}, bundle);
 			const out = String(bundle["index.html"].source);
 			expect(out).toContain("integrity=");
 		});
@@ -327,7 +327,7 @@ describe("vite-plugin-sri-gen", () => {
 				build: { ssr: true },
 			} as any);
 			// Call with plugin context containing warn()
-			await plugin.generateBundle.call(mockContext, {}, {} as any);
+			await plugin.writeBundle.call(mockContext, {}, {} as any);
 			expect(mockContext.warn).toHaveBeenCalled();
 		});
 	});
@@ -338,7 +338,7 @@ describe("vite-plugin-sri-gen", () => {
 			const mockContext = createMockPluginContext();
 
 			// First create the logger by calling generateBundle once
-			await plugin.generateBundle.call(mockContext, {}, {
+			await plugin.writeBundle.call(mockContext, {}, {
 				"test.js": { type: "chunk", code: "console.log('test')" },
 			} as any);
 
@@ -469,7 +469,7 @@ describe("vite-plugin-sri-gen", () => {
 					source: cssBytes,
 				},
 			};
-			await plugin.generateBundle({}, bundle);
+			await plugin.writeBundle({}, bundle);
 			// This test ensures binary source handling works without throwing errors
 		});
 
@@ -490,7 +490,7 @@ describe("vite-plugin-sri-gen", () => {
 					source: "console.log('ok')",
 				},
 			};
-			await plugin.generateBundle({}, bundle);
+			await plugin.writeBundle({}, bundle);
 		});
 	});
 
@@ -522,7 +522,7 @@ describe("vite-plugin-sri-gen", () => {
 				),
 			} as any;
 
-			await plugin.generateBundle({}, bundle as any);
+			await plugin.writeBundle({}, bundle as any);
 			const out = String((bundle["index.html"] as Asset).source);
 
 			// Should inject rel=modulepreload with base-prefixed href, integrity and crossorigin
@@ -553,7 +553,7 @@ describe("vite-plugin-sri-gen", () => {
 				),
 			} as any;
 
-			await plugin.generateBundle({}, bundle as any);
+			await plugin.writeBundle({}, bundle as any);
 			const out = String((bundle["index.html"] as Asset).source);
 
 			// Only one occurrence expected
@@ -592,7 +592,7 @@ describe("vite-plugin-sri-gen", () => {
 				),
 			} as any;
 
-			await plugin.generateBundle({}, bundle as any);
+			await plugin.writeBundle({}, bundle as any);
 			const out = String((bundle["index.html"] as Asset).source);
 
 			expect(out).not.toContain(
@@ -654,7 +654,7 @@ describe("vite-plugin-sri-gen", () => {
 				[dyn.fileName]: dyn,
 			} as any;
 
-			await plugin.generateBundle({}, bundle as any);
+			await plugin.writeBundle({}, bundle as any);
 			const out = String((bundle["index.html"] as Asset).source);
 			expect(out).toMatch(
 				/<link rel="modulepreload" href="\/base\/assets\/chunk-by-name\.js" integrity="sha256-/
@@ -680,7 +680,7 @@ describe("vite-plugin-sri-gen", () => {
 					"src/chunkA.ts"
 				),
 			} as any;
-			await plugin.generateBundle({}, bundle as any);
+			await plugin.writeBundle({}, bundle as any);
 			const out = String((bundle["index.html"] as Asset).source);
 			expect(out).toMatch(
 				/<link rel="modulepreload" href="\/assets\/chunk-A\.js" integrity="sha256-[^"]+">/
@@ -714,7 +714,7 @@ describe("vite-plugin-sri-gen", () => {
 				[entry.fileName]: entry,
 				[dyn.fileName]: dyn,
 			} as any;
-			await plugin.generateBundle({}, bundle as any);
+			await plugin.writeBundle({}, bundle as any);
 			const out = String((bundle["index.html"] as Asset).source);
 			expect(out).toMatch(
 				/<link rel="modulepreload" href="\/base\/assets\/chunk-by-name\.js" integrity="sha256-/
@@ -735,7 +735,7 @@ describe("vite-plugin-sri-gen", () => {
 			const plugin = sri({ crossorigin: "anonymous" }) as any;
 			// Build SRI map by running generateBundle on a bundle with one JS asset
 			const bundle = makeBundle("assets/chunk-A.js", "console.log('A')");
-			await plugin.generateBundle({}, bundle as any);
+			await plugin.writeBundle({}, bundle as any);
 
 			const result = plugin.renderChunk("console.log('x')", {
 				isEntry: true,
@@ -757,7 +757,7 @@ describe("vite-plugin-sri-gen", () => {
 		it("sets integrity but omits crossorigin when not configured", async () => {
 			const plugin = sri() as any; // no crossorigin option
 			const bundle = makeBundle("assets/chunk-B.js", "console.log('B')");
-			await plugin.generateBundle({}, bundle as any);
+			await plugin.writeBundle({}, bundle as any);
 
 			const result = plugin.renderChunk("console.log('y')", {
 				isEntry: true,
@@ -776,7 +776,7 @@ describe("vite-plugin-sri-gen", () => {
 		it("sets integrity for scripts via setAttribute path", async () => {
 			const plugin = sri() as any;
 			const bundle = makeBundle("assets/mod.js", "export{};");
-			await plugin.generateBundle({}, bundle as any);
+			await plugin.writeBundle({}, bundle as any);
 			const result = plugin.renderChunk("console.log('z')", {
 				isEntry: true,
 			} as any);
@@ -794,7 +794,7 @@ describe("vite-plugin-sri-gen", () => {
 
 			const plugin = sri({ crossorigin: "anonymous" }) as any;
 			const bundle = makeBundle("assets/ins.js", "export{};");
-			await plugin.generateBundle({}, bundle as any);
+			await plugin.writeBundle({}, bundle as any);
 			const result = plugin.renderChunk("console.log('i')", {
 				isEntry: true,
 			} as any);
@@ -996,7 +996,7 @@ describe("vite-plugin-sri-gen", () => {
 
 			// Should throw the error after handling it
 			await expect(
-				plugin.generateBundle.call(mockContext, {}, bundle)
+				plugin.writeBundle.call(mockContext, {}, bundle)
 			).rejects.toThrow("Simulated integrity mapping error");
 
 			// Restore the spy
@@ -1024,7 +1024,7 @@ describe("vite-plugin-sri-gen", () => {
 				},
 			};
 
-			await plugin.generateBundle({}, bundle);
+			await plugin.writeBundle({}, bundle);
 
 			// Should call console.error for the error message and error object in development
 			expect(spies.error).toHaveBeenCalledWith(
@@ -1052,7 +1052,7 @@ describe("vite-plugin-sri-gen", () => {
 			};
 
 			// Call with plugin context that has an error method
-			await plugin.generateBundle.call(mockContext, {}, bundle);
+			await plugin.writeBundle.call(mockContext, {}, bundle);
 
 			// The plugin error method should be called for HTML processing errors
 			// (Error is caught at HTML processor level, so just verify plugin context exists)
@@ -1075,7 +1075,7 @@ describe("vite-plugin-sri-gen", () => {
 			};
 
 			// Call without plugin context to use console fallback
-			await plugin.generateBundle({}, bundle);
+			await plugin.writeBundle({}, bundle);
 
 			expect(spies.error).toHaveBeenCalledWith(
 				expect.stringContaining("Failed to process HTML file"),
@@ -1104,7 +1104,7 @@ describe("vite-plugin-sri-gen", () => {
 				},
 			};
 
-			await plugin.generateBundle({}, bundle);
+			await plugin.writeBundle({}, bundle);
 
 			// Should log all info messages including completion
 			expect(spies.info).toHaveBeenCalledWith(
@@ -1136,7 +1136,7 @@ describe("vite-plugin-sri-gen", () => {
 			// Should throw and call handleGenerateBundleError
 			// This test primarily covers the validation path, not actual error throwing.
 			// The bundle with null code will be handled gracefully (skipped), not thrown.
-			const result = await plugin.generateBundle({}, bundle);
+			const result = await plugin.writeBundle({}, bundle);
 			expect(result).toBeUndefined();
 		});
 
@@ -1158,7 +1158,7 @@ describe("vite-plugin-sri-gen", () => {
 				},
 			};
 
-			await plugin.generateBundle({}, bundle);
+			await plugin.writeBundle({}, bundle);
 
 			// In production, info is still logged by the BundleLogger implementation
 			expect(spies.info).toHaveBeenCalled();
@@ -1171,7 +1171,7 @@ describe("vite-plugin-sri-gen", () => {
 			const { spies, cleanup } = spyOnConsole();
 			const plugin = sri() as any;
 
-			await plugin.generateBundle({}, {});
+			await plugin.writeBundle({}, {});
 
 			expect(spies.warn).toHaveBeenCalledWith(
 				expect.stringContaining("Empty bundle detected")
@@ -1185,14 +1185,14 @@ describe("vite-plugin-sri-gen", () => {
 			const plugin = sri() as any;
 
 			// Test with null bundle
-			await plugin.generateBundle({}, null);
+			await plugin.writeBundle({}, null);
 
 			expect(spies.warn).toHaveBeenCalledWith(
 				expect.stringContaining("Invalid bundle provided")
 			);
 
 			// Test with non-object bundle
-			await plugin.generateBundle({}, "not-an-object");
+			await plugin.writeBundle({}, "not-an-object");
 
 			expect(spies.warn).toHaveBeenCalledWith(
 				expect.stringContaining("Invalid bundle provided")
@@ -1232,7 +1232,7 @@ describe("vite-plugin-sri-gen", () => {
 				// Note: missing the actual "missing-chunk.js" file to trigger the warning
 			};
 
-			await plugin.generateBundle({}, bundle);
+			await plugin.writeBundle({}, bundle);
 
 			// Should warn about unresolved dynamic import (different path hit)
 			expect(spies.warn).toHaveBeenCalledWith(
@@ -1379,7 +1379,7 @@ describe("vite-plugin-sri-gen", () => {
 		it("handles error in maybeSetIntegrity during node insertion", async () => {
 			const plugin = sri() as any;
 			const bundle = makeBundle("assets/error.js", "export default 42;");
-			await plugin.generateBundle({}, bundle as any);
+			await plugin.writeBundle({}, bundle as any);
 
 			const result = plugin.renderChunk("console.log('test')", {
 				isEntry: true,

--- a/test/internal.spec.ts
+++ b/test/internal.spec.ts
@@ -627,7 +627,7 @@ describe("Processing Classes", () => {
 			};
 
 			// Should process without throwing
-			await plugin.generateBundle({}, bundle);
+			await plugin.writeBundle({}, bundle);
 
 			// Check that HTML was processed
 			const processedHtml = String(bundle["index.html"].source);
@@ -656,7 +656,7 @@ describe("Processing Classes", () => {
 			};
 
 			// Should handle gracefully without throwing
-			await plugin.generateBundle({}, bundle);
+			await plugin.writeBundle({}, bundle);
 		});
 
 		it("handles integrity computation errors", async () => {
@@ -683,7 +683,7 @@ describe("Processing Classes", () => {
 			};
 
 			// Should handle any errors gracefully
-			await plugin.generateBundle({}, bundle);
+			await plugin.writeBundle({}, bundle);
 
 			cleanup();
 		});
@@ -713,7 +713,7 @@ describe("Processing Classes", () => {
 				};
 			}
 
-			await plugin.generateBundle({}, bundle);
+			await plugin.writeBundle({}, bundle);
 		});
 
 		it("builds integrity mappings directly", async () => {
@@ -832,7 +832,7 @@ describe("Processing Classes", () => {
 				},
 			};
 
-			await plugin.generateBundle({}, bundle);
+			await plugin.writeBundle({}, bundle);
 
 			// Check that HTML includes preload links for dynamic chunks
 			const processedHtml = String(bundle["index.html"].source);


### PR DESCRIPTION
This pull request updates the Vite SRI plugin to improve its integration with Vite's plugin lifecycle and enhances maintainability. The main change is renaming the core lifecycle hook from `generateBundle` to `writeBundle`, aligning with Vite's expectations and ensuring SRI processing occurs after the bundle has been written. The update also introduces new plugin properties for better ordering and execution control, and updates all related tests accordingly.

**Plugin lifecycle and API alignment:**

* Changed the main lifecycle hook from `generateBundle` to `writeBundle` in `src/index.ts`, ensuring SRI processing happens after the bundle is written, which matches Vite's plugin lifecycle.
* Added `order: "post"` and `sequential: true` properties to the plugin definition to guarantee correct execution order and avoid concurrency issues.

**Versioning:**

* Bumped the package version from `1.2.0` to `1.2.1` in `package.json` to reflect these changes.