### PR TITLE
ci(workflow): Automate release version bumps

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,8 @@ charset = utf-8
 [*.{json,js,jsx,ts,tsx,mjs,cjs}]
 indent_style = tab
 indent_size = 4
+
+
+[*.{yaml,yml}]
+indent_style = space
+indent_size = 2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,13 +4,13 @@ on:
   pull_request:
   push:
     branches:
-    - main
+      - main
     paths:
-      - 'src/**'
-      - '.github/workflows/build.yml'
-      - 'package.json'
-      - 'tsconfig.json'
-      - 'vite.config.ts'
+      - "src/**"
+      - ".github/workflows/build.yml"
+      - "package.json"
+      - "tsconfig.json"
+      - "vite.config.ts"
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: "20.x"
       - name: Install Dependencies
         run: npm ci
       - name: Build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,7 @@
 name: Publish 🚀
 permissions:
   id-token: write
+  contents: write
 on:
   release:
     types: [published]
@@ -9,10 +10,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: main
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
-          registry-url: 'https://registry.npmjs.org'
+          node-version: "20.x"
+          registry-url: "https://registry.npmjs.org"
+      - name: Update version from release tag
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: |
+          VERSION="${TAG_NAME#v}"
+          npm version "$VERSION" --no-git-tag-version
+      - name: Commit and push version update
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: |
+          VERSION="${TAG_NAME#v}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add package.json package-lock.json
+          git commit -m "chore: bumped version to $VERSION for release"
+          git push origin main
       - name: Install Dependencies
         run: npm ci
       - name: Build 🏗️

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,13 +4,13 @@ on:
   pull_request:
   push:
     branches:
-    - main
+      - main
     paths:
-      - 'src/**'
-      - '.github/workflows/test.yml'
-      - 'package.json'
-      - 'tsconfig.json'
-      - 'vite.config.ts'
+      - "src/**"
+      - ".github/workflows/test.yml"
+      - "package.json"
+      - "tsconfig.json"
+      - "vite.config.ts"
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -18,8 +18,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
-          cache: 'npm'
+          node-version: "20.x"
+          cache: "npm"
       - run: npm ci
       - name: Run Unit Tests
         run: npm run test:cov


### PR DESCRIPTION
Changes:
- Updated `publish.yml` to automatically bump the package version based on the release tag and push the change back to the main branch.
  - Added `contents: write` permissions to the publish workflow.
- Added YAML specific indentation rules to `.editorconfig`.
  - Applied standardized YAML formatting and indentation across all GitHub Action workflows.
