### PR TITLE
feat(logging): Reduce logging noise with verboseLogging parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ export default {
       fetchCache: true, // cache remote fetches in-memory and dedupe concurrent requests (default: true)
       fetchTimeoutMs: 5000, // abort remote fetches after N ms; 0 disables timeout (default: 5000)
       skipResources: [], // skip SRI for resources matching these patterns (default: [])
+      verboseLogging: true, // show all info-level build logs (default: false)
     }),
   ],
 };
@@ -103,6 +104,7 @@ type SriPluginOptions = {
   preloadDynamicChunks?: boolean; // default: true. Inject rel="modulepreload" with integrity for discovered lazy chunks
   runtimePatchDynamicLinks?: boolean; // default: true. Inject a tiny runtime that adds integrity to dynamically created <script>/<link>
   skipResources?: string[]; // default: []. Skip SRI for resources matching these patterns (by id or src/href)
+  verboseLogging?: boolean; // default: false. Show all info-level build logs. When false, only warnings, errors, and a completion summary are shown.
 };
 ```
 
@@ -115,6 +117,7 @@ Notes:
 - Invalid or unsupported algorithms are automatically replaced with 'sha384' and a warning is logged.
 - Caching: when enabled, remote fetches are cached in-memory per build and concurrent requests are deduplicated.
 - Timeout: when a non-zero fetchTimeoutMs is set, slow remote fetches are aborted and the affected elements are left unchanged (a warning is logged).
+- Logging: by default, the plugin runs quietly — only warnings, errors, and a single completion summary line are printed. Set `verboseLogging: true` to see detailed step-by-step info messages during the build.
 
 ### Skipping Resources
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1037,10 +1037,8 @@ describe("vite-plugin-sri-gen", () => {
 			cleanup();
 		});
 
-		it("covers successful completion info logging in development", async () => {
+		it("covers successful completion summary logging", async () => {
 			const { spies, cleanup } = spyOnConsole();
-			const originalEnv = process.env.NODE_ENV;
-			process.env.NODE_ENV = "development";
 
 			const plugin = sri() as any;
 
@@ -1048,6 +1046,7 @@ describe("vite-plugin-sri-gen", () => {
 				"index.html": {
 					type: "asset",
 					source: "<!DOCTYPE html><html><head></head><body></body></html>",
+					fileName: "index.html",
 				},
 				"main.js": {
 					type: "chunk",
@@ -1058,15 +1057,43 @@ describe("vite-plugin-sri-gen", () => {
 
 			await plugin.generateBundle.handler({}, bundle);
 
-			// Should log all info messages including completion
+			// Default (quiet) mode: info is suppressed, but summary always prints
+			expect(spies.info).toHaveBeenCalledWith(
+				expect.stringContaining("SRI generation completed")
+			);
+
+			cleanup();
+		});
+
+		it("covers verbose logging shows all info messages", async () => {
+			const { spies, cleanup } = spyOnConsole();
+
+			const plugin = sri({ verboseLogging: true }) as any;
+
+			const bundle: any = {
+				"index.html": {
+					type: "asset",
+					source: "<!DOCTYPE html><html><head></head><body></body></html>",
+					fileName: "index.html",
+				},
+				"main.js": {
+					type: "chunk",
+					fileName: "main.js",
+					code: "console.log('test');",
+				},
+			};
+
+			await plugin.generateBundle.handler({}, bundle);
+
+			// Verbose mode: info messages are visible
 			expect(spies.info).toHaveBeenCalledWith(
 				expect.stringContaining("Building SRI integrity mappings")
 			);
+			// Summary always prints
 			expect(spies.info).toHaveBeenCalledWith(
-				expect.stringContaining("SRI generation completed successfully")
+				expect.stringContaining("SRI generation completed")
 			);
 
-			process.env.NODE_ENV = originalEnv;
 			cleanup();
 		});
 
@@ -1092,16 +1119,15 @@ describe("vite-plugin-sri-gen", () => {
 			expect(result).toBeUndefined();
 		});
 
-		it("covers production mode (no info logging)", async () => {
+		it("covers default quiet mode (summary still prints)", async () => {
 			const { spies, cleanup } = spyOnConsole();
-			const originalEnv = process.env.NODE_ENV;
-			process.env.NODE_ENV = "production";
 
 			const plugin = sri() as any;
 			const bundle: any = {
 				"index.html": {
 					type: "asset",
 					source: "<!DOCTYPE html><html></html>",
+					fileName: "index.html",
 				},
 				"test.js": {
 					type: "chunk",
@@ -1112,10 +1138,11 @@ describe("vite-plugin-sri-gen", () => {
 
 			await plugin.generateBundle.handler({}, bundle);
 
-			// In production, info is still logged by the BundleLogger implementation
-			expect(spies.info).toHaveBeenCalled();
+			// In default quiet mode, summary still prints via console.info
+			expect(spies.info).toHaveBeenCalledWith(
+				expect.stringContaining("SRI generation completed")
+			);
 
-			process.env.NODE_ENV = originalEnv;
 			cleanup();
 		});
 
@@ -1662,6 +1689,167 @@ describe("vite-plugin-sri-gen", () => {
 					dependencies
 				);
 			}).not.toThrow();
+		});
+	});
+
+	describe("verboseLogging Option", () => {
+		it("suppresses info logs in default (quiet) mode", async () => {
+			const mockContext = createMockPluginContext();
+			const plugin = sri() as any;
+
+			const bundle: any = {
+				"index.html": {
+					type: "asset",
+					source: "<!DOCTYPE html><html><head></head><body></body></html>",
+					fileName: "index.html",
+				},
+				"main.js": {
+					type: "chunk",
+					fileName: "main.js",
+					code: "console.log('test');",
+				},
+			};
+
+			await plugin.generateBundle.handler.call(mockContext, {}, bundle);
+
+			// info should not be called with step-level messages (they are suppressed)
+			expect(mockContext.info).not.toHaveBeenCalledWith(
+				"Building SRI integrity mappings for bundle assets"
+			);
+			expect(mockContext.info).not.toHaveBeenCalledWith(
+				"Analyzing dynamic import relationships"
+			);
+			expect(mockContext.info).not.toHaveBeenCalledWith(
+				"Processing HTML files for SRI injection"
+			);
+
+			// summary always prints via info
+			expect(mockContext.info).toHaveBeenCalledWith(
+				expect.stringContaining("SRI generation completed")
+			);
+		});
+
+		it("shows all info logs when verboseLogging is true", async () => {
+			const mockContext = createMockPluginContext();
+			const plugin = sri({ verboseLogging: true }) as any;
+
+			const bundle: any = {
+				"index.html": {
+					type: "asset",
+					source: "<!DOCTYPE html><html><head></head><body></body></html>",
+					fileName: "index.html",
+				},
+				"main.js": {
+					type: "chunk",
+					fileName: "main.js",
+					code: "console.log('test');",
+				},
+			};
+
+			await plugin.generateBundle.handler.call(mockContext, {}, bundle);
+
+			// All info messages should be visible in verbose mode
+			expect(mockContext.info).toHaveBeenCalledWith(
+				"Building SRI integrity mappings for bundle assets"
+			);
+			expect(mockContext.info).toHaveBeenCalledWith(
+				"Analyzing dynamic import relationships"
+			);
+			expect(mockContext.info).toHaveBeenCalledWith(
+				"Processing HTML files for SRI injection"
+			);
+
+			// summary always prints
+			expect(mockContext.info).toHaveBeenCalledWith(
+				expect.stringContaining("SRI generation completed")
+			);
+		});
+
+		it("explicit verboseLogging: false behaves same as default", async () => {
+			const mockContext = createMockPluginContext();
+			const plugin = sri({ verboseLogging: false }) as any;
+
+			const bundle: any = {
+				"index.html": {
+					type: "asset",
+					source: "<!DOCTYPE html><html><head></head><body></body></html>",
+					fileName: "index.html",
+				},
+				"main.js": {
+					type: "chunk",
+					fileName: "main.js",
+					code: "console.log('test');",
+				},
+			};
+
+			await plugin.generateBundle.handler.call(mockContext, {}, bundle);
+
+			// info suppressed
+			expect(mockContext.info).not.toHaveBeenCalledWith(
+				"Building SRI integrity mappings for bundle assets"
+			);
+
+			// summary always prints
+			expect(mockContext.info).toHaveBeenCalledWith(
+				expect.stringContaining("SRI generation completed")
+			);
+		});
+
+		it("warnings still print in quiet mode", async () => {
+			const mockContext = createMockPluginContext();
+			const plugin = sri() as any;
+
+			// Simulate SSR build with no HTML to trigger a warning
+			plugin.configResolved?.({
+				command: "build",
+				mode: "production",
+				appType: "ssr",
+				build: { ssr: true },
+			} as any);
+
+			const bundle: any = { "entry.js": { code: "console.log(1)" } };
+			await plugin.generateBundle.handler.call(mockContext, {}, bundle);
+
+			// warn is always called regardless of verbose setting
+			expect(mockContext.warn).toHaveBeenCalled();
+		});
+
+		it("summary includes asset and HTML counts", async () => {
+			const mockContext = createMockPluginContext();
+			const plugin = sri() as any;
+
+			const bundle: any = {
+				"index.html": {
+					type: "asset",
+					source: "<!DOCTYPE html><html><head></head><body></body></html>",
+					fileName: "index.html",
+				},
+				"about.html": {
+					type: "asset",
+					source: "<!DOCTYPE html><html><head></head><body></body></html>",
+					fileName: "about.html",
+				},
+				"main.js": {
+					type: "chunk",
+					fileName: "main.js",
+					code: "console.log('test');",
+				},
+				"style.css": {
+					type: "asset",
+					fileName: "style.css",
+					source: "body{}",
+				},
+			};
+
+			await plugin.generateBundle.handler.call(mockContext, {}, bundle);
+
+			// Summary should mention asset and HTML counts
+			expect(mockContext.info).toHaveBeenCalledWith(
+				expect.stringContaining("asset(s) processed")
+			);
+			expect(mockContext.info).toHaveBeenCalledWith(
+				expect.stringContaining("HTML file(s) updated")
+			);
 		});
 	});
 });

--- a/test/mocks/bundle-logger.ts
+++ b/test/mocks/bundle-logger.ts
@@ -9,6 +9,7 @@ export interface MockBundleLogger extends BundleLogger {
 	info: MockedFunction<(message: string) => void>;
 	warn: MockedFunction<(message: string) => void>;
 	error: MockedFunction<(message: string, error?: Error) => void>;
+	summary: MockedFunction<(message: string) => void>;
 }
 
 /**
@@ -19,6 +20,7 @@ export function createMockBundleLogger(): MockBundleLogger {
 		info: vi.fn(),
 		warn: vi.fn(),
 		error: vi.fn(),
+		summary: vi.fn(),
 	};
 }
 


### PR DESCRIPTION
Introducing a `verboseLogging` option to control build-time output. By default, the plugin now runs in a "quiet" mode that suppresses step-by-step info messages while still providing a final completion summary.

- Added `verboseLogging` to `SriPluginOptions` (default: false)
- Implemented `summary` method in `BundleLogger` for persistent reporting
- Updated `createLogger` to handle conditional info-level suppression
- Enhanced completion message to include asset and HTML file counts
- Updated documentation and test suite to cover new logging behavior

Resolves issue https://github.com/rbonestell/vite-plugin-sri-gen/issues/9