### PR TITLE
feat: inject SRI hashes into Vite manifest (#23)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@
 .serena/*
 .kilocode/*
 
+### Misc ###
+docs/
+temp/
+
 ### Node ###
 # Logs
 logs

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@
 - [Skipping Resources](#skipping-resources)
 - [Lazy-loaded Chunks and Dynamic Tags](#lazy-loaded-chunks-and-dynamic-tags)
 - [Runtime Patching](#runtime-patching)
+- [Vite Manifest Integration](#vite-manifest-integration)
 - [Compatibility](#compatibility)
 - [Examples](#examples)
 - [Contributing](#contributing)
@@ -181,6 +182,48 @@ The runtime only processes elements that are eligible for SRI:
 ### Skip patterns
 
 The runtime respects `skipResources` patterns, allowing you to exclude specific resources from automatic SRI injection even when created dynamically.
+
+## Vite Manifest Integration
+
+When Vite emits a build manifest (`build.manifest: true`), this plugin automatically augments it with integrity values. This is useful when your backend owns HTML generation and reads the manifest to know which assets to load — the backend can now attach `integrity` without re-hashing the files.
+
+The feature is automatic and purely additive: if no manifest is emitted, nothing changes. Both the modern `.vite/manifest.json` (Vite ≥ 4.3) and the legacy `manifest.json` locations are recognized. The SSR manifest (`.vite/ssr-manifest.json`) is left alone — it has a different schema.
+
+### Augmented schema
+
+Two fields are added per entry:
+
+- `integrity` — SRI hash for the entry's primary `file`, when the file is a JS or CSS asset the plugin already hashes.
+- `cssIntegrity` — parallel `(string | null)[]` array aligned 1:1 with `css[]`. A `null` at index `i` means `css[i]` has no hash (non-JS/CSS file, or excluded via `skipResources`).
+
+Example manifest after augmentation:
+
+```json
+{
+  "src/main.tsx": {
+    "file": "assets/main-XYZ.js",
+    "integrity": "sha384-...",
+    "src": "src/main.tsx",
+    "isEntry": true,
+    "css": ["assets/main-ABC.css"],
+    "cssIntegrity": ["sha384-..."],
+    "imports": ["_shared-GHI.js"]
+  },
+  "_shared-GHI.js": {
+    "file": "_shared-GHI.js",
+    "integrity": "sha384-..."
+  }
+}
+```
+
+Consumers resolve `imports` / `dynamicImports` by key lookup into the manifest, so no special handling of those arrays is needed.
+
+### Notes
+
+- Existing `integrity` or `cssIntegrity` values on an entry are preserved and never overwritten.
+- `skipResources` patterns are honored: matching files get no integrity in the manifest, keeping behavior consistent with HTML injection and runtime patching.
+- Only JS and CSS files are hashed (matching the rest of the plugin). Entries in `assets` (images, fonts, etc.) are untouched.
+- If the manifest fails to parse, a warning is logged and the asset is left unchanged; the rest of the build continues.
 
 ## Compatibility
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ The runtime respects `skipResources` patterns, allowing you to exclude specific 
 
 When Vite emits a build manifest (`build.manifest: true`), this plugin automatically augments it with integrity values. This is useful when your backend owns HTML generation and reads the manifest to know which assets to load — the backend can now attach `integrity` without re-hashing the files.
 
-The feature is automatic and purely additive: if no manifest is emitted, nothing changes. Both the modern `.vite/manifest.json` (Vite ≥ 4.3) and the legacy `manifest.json` locations are recognized. The SSR manifest (`.vite/ssr-manifest.json`) is left alone — it has a different schema.
+The feature is automatic and purely additive: if no manifest is emitted, nothing changes. It runs even when the bundle emits no HTML files, which is the common case for backend-owned HTML generation. Both the modern `.vite/manifest.json` (Vite ≥ 4.3) and the legacy `manifest.json` locations are recognized. Custom manifest filenames (when `build.manifest` is set to a string ending in `manifest.json`) are also detected, but only augmented if their contents match the Vite manifest shape — so unrelated JSON assets that happen to share the suffix (e.g. PWA Web App manifests) are left alone. The SSR manifest (`.vite/ssr-manifest.json`) is never touched — it has a different schema.
 
 ### Augmented schema
 
@@ -196,18 +196,18 @@ Two fields are added per entry:
 - `integrity` — SRI hash for the entry's primary `file`, when the file is a JS or CSS asset the plugin already hashes.
 - `cssIntegrity` — parallel `(string | null)[]` array aligned 1:1 with `css[]`. A `null` at index `i` means `css[i]` has no hash (non-JS/CSS file, or excluded via `skipResources`).
 
-Example manifest after augmentation:
+Both fields are appended to each entry, so they appear after any existing Vite-emitted keys in the serialized JSON. Example manifest after augmentation:
 
 ```json
 {
   "src/main.tsx": {
     "file": "assets/main-XYZ.js",
-    "integrity": "sha384-...",
     "src": "src/main.tsx",
     "isEntry": true,
     "css": ["assets/main-ABC.css"],
-    "cssIntegrity": ["sha384-..."],
-    "imports": ["_shared-GHI.js"]
+    "imports": ["_shared-GHI.js"],
+    "integrity": "sha384-...",
+    "cssIntegrity": ["sha384-..."]
   },
   "_shared-GHI.js": {
     "file": "_shared-GHI.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -754,29 +754,6 @@
 				"url": "https://github.com/sponsors/nzakas"
 			}
 		},
-		"node_modules/@isaacs/balanced-match": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
-			"integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "20 || >=22"
-			}
-		},
-		"node_modules/@isaacs/brace-expansion": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
-			"integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@isaacs/balanced-match": "^4.0.1"
-			},
-			"engines": {
-				"node": "20 || >=22"
-			}
-		},
 		"node_modules/@isaacs/cliui": {
 			"version": "8.0.2",
 			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -979,9 +956,9 @@
 			}
 		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
-			"version": "4.46.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.46.2.tgz",
-			"integrity": "sha512-Zj3Hl6sN34xJtMv7Anwb5Gu01yujyE/cLBDB2gnHTAHaWS1Z38L7kuSG+oAh0giZMqG060f/YBStXtMH6FvPMA==",
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+			"integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
 			"cpu": [
 				"arm"
 			],
@@ -992,9 +969,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-android-arm64": {
-			"version": "4.46.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.46.2.tgz",
-			"integrity": "sha512-nTeCWY83kN64oQ5MGz3CgtPx8NSOhC5lWtsjTs+8JAJNLcP3QbLCtDDgUKQc/Ro/frpMq4SHUaHN6AMltcEoLQ==",
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+			"integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1005,9 +982,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-darwin-arm64": {
-			"version": "4.46.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.46.2.tgz",
-			"integrity": "sha512-HV7bW2Fb/F5KPdM/9bApunQh68YVDU8sO8BvcW9OngQVN3HHHkw99wFupuUJfGR9pYLLAjcAOA6iO+evsbBaPQ==",
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+			"integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
 			"cpu": [
 				"arm64"
 			],
@@ -1018,9 +995,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-darwin-x64": {
-			"version": "4.46.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.46.2.tgz",
-			"integrity": "sha512-SSj8TlYV5nJixSsm/y3QXfhspSiLYP11zpfwp6G/YDXctf3Xkdnk4woJIF5VQe0of2OjzTt8EsxnJDCdHd2xMA==",
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+			"integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
 			"cpu": [
 				"x64"
 			],
@@ -1031,9 +1008,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-freebsd-arm64": {
-			"version": "4.46.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.46.2.tgz",
-			"integrity": "sha512-ZyrsG4TIT9xnOlLsSSi9w/X29tCbK1yegE49RYm3tu3wF1L/B6LVMqnEWyDB26d9Ecx9zrmXCiPmIabVuLmNSg==",
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+			"integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1044,9 +1021,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-freebsd-x64": {
-			"version": "4.46.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.46.2.tgz",
-			"integrity": "sha512-pCgHFoOECwVCJ5GFq8+gR8SBKnMO+xe5UEqbemxBpCKYQddRQMgomv1104RnLSg7nNvgKy05sLsY51+OVRyiVw==",
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+			"integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1057,11 +1034,14 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-			"version": "4.46.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.46.2.tgz",
-			"integrity": "sha512-EtP8aquZ0xQg0ETFcxUbU71MZlHaw9MChwrQzatiE8U/bvi5uv/oChExXC4mWhjiqK7azGJBqU0tt5H123SzVA==",
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+			"integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
 			"cpu": [
 				"arm"
+			],
+			"libc": [
+				"glibc"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -1070,11 +1050,14 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
-			"version": "4.46.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.46.2.tgz",
-			"integrity": "sha512-qO7F7U3u1nfxYRPM8HqFtLd+raev2K137dsV08q/LRKRLEc7RsiDWihUnrINdsWQxPR9jqZ8DIIZ1zJJAm5PjQ==",
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+			"integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
 			"cpu": [
 				"arm"
+			],
+			"libc": [
+				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -1083,11 +1066,14 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-gnu": {
-			"version": "4.46.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.46.2.tgz",
-			"integrity": "sha512-3dRaqLfcOXYsfvw5xMrxAk9Lb1f395gkoBYzSFcc/scgRFptRXL9DOaDpMiehf9CO8ZDRJW2z45b6fpU5nwjng==",
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+			"integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
 			"cpu": [
 				"arm64"
+			],
+			"libc": [
+				"glibc"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -1096,11 +1082,14 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-musl": {
-			"version": "4.46.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.46.2.tgz",
-			"integrity": "sha512-fhHFTutA7SM+IrR6lIfiHskxmpmPTJUXpWIsBXpeEwNgZzZZSg/q4i6FU4J8qOGyJ0TR+wXBwx/L7Ho9z0+uDg==",
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+			"integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
 			"cpu": [
 				"arm64"
+			],
+			"libc": [
+				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -1108,12 +1097,31 @@
 				"linux"
 			]
 		},
-		"node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-			"version": "4.46.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.46.2.tgz",
-			"integrity": "sha512-i7wfGFXu8x4+FRqPymzjD+Hyav8l95UIZ773j7J7zRYc3Xsxy2wIn4x+llpunexXe6laaO72iEjeeGyUFmjKeA==",
+		"node_modules/@rollup/rollup-linux-loong64-gnu": {
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+			"integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
 			"cpu": [
 				"loong64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-loong64-musl": {
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+			"integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+			"cpu": [
+				"loong64"
+			],
+			"libc": [
+				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -1122,11 +1130,30 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-ppc64-gnu": {
-			"version": "4.46.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.46.2.tgz",
-			"integrity": "sha512-B/l0dFcHVUnqcGZWKcWBSV2PF01YUt0Rvlurci5P+neqY/yMKchGU8ullZvIv5e8Y1C6wOn+U03mrDylP5q9Yw==",
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+			"integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
 			"cpu": [
 				"ppc64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-ppc64-musl": {
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+			"integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"libc": [
+				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -1135,11 +1162,14 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
-			"version": "4.46.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.46.2.tgz",
-			"integrity": "sha512-32k4ENb5ygtkMwPMucAb8MtV8olkPT03oiTxJbgkJa7lJ7dZMr0GCFJlyvy+K8iq7F/iuOr41ZdUHaOiqyR3iQ==",
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+			"integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
 			"cpu": [
 				"riscv64"
+			],
+			"libc": [
+				"glibc"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -1148,11 +1178,14 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-musl": {
-			"version": "4.46.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.46.2.tgz",
-			"integrity": "sha512-t5B2loThlFEauloaQkZg9gxV05BYeITLvLkWOkRXogP4qHXLkWSbSHKM9S6H1schf/0YGP/qNKtiISlxvfmmZw==",
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+			"integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
 			"cpu": [
 				"riscv64"
+			],
+			"libc": [
+				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -1161,11 +1194,14 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-s390x-gnu": {
-			"version": "4.46.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.46.2.tgz",
-			"integrity": "sha512-YKjekwTEKgbB7n17gmODSmJVUIvj8CX7q5442/CK80L8nqOUbMtf8b01QkG3jOqyr1rotrAnW6B/qiHwfcuWQA==",
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+			"integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
 			"cpu": [
 				"s390x"
+			],
+			"libc": [
+				"glibc"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -1174,11 +1210,14 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-gnu": {
-			"version": "4.46.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.46.2.tgz",
-			"integrity": "sha512-Jj5a9RUoe5ra+MEyERkDKLwTXVu6s3aACP51nkfnK9wJTraCC8IMe3snOfALkrjTYd2G1ViE1hICj0fZ7ALBPA==",
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+			"integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
 			"cpu": [
 				"x64"
+			],
+			"libc": [
+				"glibc"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -1187,11 +1226,14 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-musl": {
-			"version": "4.46.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.46.2.tgz",
-			"integrity": "sha512-7kX69DIrBeD7yNp4A5b81izs8BqoZkCIaxQaOpumcJ1S/kmqNFjPhDu1LHeVXv0SexfHQv5cqHsxLOjETuqDuA==",
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+			"integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
 			"cpu": [
 				"x64"
+			],
+			"libc": [
+				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -1199,10 +1241,36 @@
 				"linux"
 			]
 		},
+		"node_modules/@rollup/rollup-openbsd-x64": {
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+			"integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			]
+		},
+		"node_modules/@rollup/rollup-openharmony-arm64": {
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+			"integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			]
+		},
 		"node_modules/@rollup/rollup-win32-arm64-msvc": {
-			"version": "4.46.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.46.2.tgz",
-			"integrity": "sha512-wiJWMIpeaak/jsbaq2HMh/rzZxHVW1rU6coyeNNpMwk5isiPjSTx0a4YLSlYDwBH/WBvLz+EtsNqQScZTLJy3g==",
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+			"integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1213,9 +1281,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-ia32-msvc": {
-			"version": "4.46.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.46.2.tgz",
-			"integrity": "sha512-gBgaUDESVzMgWZhcyjfs9QFK16D8K6QZpwAaVNJxYDLHWayOta4ZMjGm/vsAEy3hvlS2GosVFlBlP9/Wb85DqQ==",
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+			"integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
 			"cpu": [
 				"ia32"
 			],
@@ -1225,10 +1293,23 @@
 				"win32"
 			]
 		},
+		"node_modules/@rollup/rollup-win32-x64-gnu": {
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+			"integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
 		"node_modules/@rollup/rollup-win32-x64-msvc": {
-			"version": "4.46.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.46.2.tgz",
-			"integrity": "sha512-CvUo2ixeIQGtF6WvuB87XWqPQkoFAFqW+HUo/WzHwuHDvIwZCtjdWXoYCcr06iKGydiqTclC4jU/TNObC/xKZg==",
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+			"integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
 			"cpu": [
 				"x64"
 			],
@@ -1281,7 +1362,6 @@
 			"integrity": "sha512-y3tBaz+rjspDTylNjAX37jEC3TETEFGNJL6uQDxwF9/8GLLIjW1rvVHlynyuUKMnMr1Roq8jOv3vkopBjC4/VA==",
 			"devOptional": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"undici-types": "~6.21.0"
 			}
@@ -1343,7 +1423,6 @@
 			"integrity": "sha512-g3WpVQHngx0aLXn6kfIYCZxM6rRJlWzEkVpqEFLT3SgEDsp9cpCbxxgwnE504q4H+ruSDh/VGS6nqZIDynP+vg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.39.0",
 				"@typescript-eslint/types": "8.39.0",
@@ -1489,9 +1568,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1499,13 +1578,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"brace-expansion": "^2.0.1"
+				"brace-expansion": "^2.0.2"
 			},
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
@@ -1711,7 +1790,6 @@
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -1730,9 +1808,9 @@
 			}
 		},
 		"node_modules/ajv": {
-			"version": "6.12.6",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+			"integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1816,9 +1894,9 @@
 			"license": "MIT"
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2123,7 +2201,6 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"esbuild": "bin/esbuild"
 			},
@@ -2188,7 +2265,6 @@
 			"integrity": "sha512-LSehfdpgMeWcTZkWZVIJl+tkZ2nuSkyyB9C27MZqFWXuph7DvaowgcTvKqxvpLW1JZIk8PN7hFY3Rj9LQ7m7lg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -2506,9 +2582,9 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-			"integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+			"integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -2590,6 +2666,29 @@
 				"node": ">=10.13.0"
 			}
 		},
+		"node_modules/glob/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/glob/node_modules/brace-expansion": {
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
 		"node_modules/glob/node_modules/jackspeak": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
@@ -2617,16 +2716,16 @@
 			}
 		},
 		"node_modules/glob/node_modules/minimatch": {
-			"version": "10.1.1",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
-			"integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"@isaacs/brace-expansion": "^5.0.0"
+				"brace-expansion": "^5.0.5"
 			},
 			"engines": {
-				"node": "20 || >=22"
+				"node": "18 || 20 || >=22"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
@@ -3055,9 +3154,9 @@
 			}
 		},
 		"node_modules/micromatch/node_modules/picomatch": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -3068,9 +3167,9 @@
 			}
 		},
 		"node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3312,11 +3411,10 @@
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -3365,7 +3463,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",
@@ -3525,9 +3622,9 @@
 			}
 		},
 		"node_modules/rollup": {
-			"version": "4.46.2",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.46.2.tgz",
-			"integrity": "sha512-WMmLFI+Boh6xbop+OAGo9cQ3OgX9MIg7xOQjn+pTCwOkk+FNDAeAemXkJ3HzDJrVXleLOFVa1ipuc1AmEx1Dwg==",
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+			"integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/estree": "1.0.8"
@@ -3540,26 +3637,31 @@
 				"npm": ">=8.0.0"
 			},
 			"optionalDependencies": {
-				"@rollup/rollup-android-arm-eabi": "4.46.2",
-				"@rollup/rollup-android-arm64": "4.46.2",
-				"@rollup/rollup-darwin-arm64": "4.46.2",
-				"@rollup/rollup-darwin-x64": "4.46.2",
-				"@rollup/rollup-freebsd-arm64": "4.46.2",
-				"@rollup/rollup-freebsd-x64": "4.46.2",
-				"@rollup/rollup-linux-arm-gnueabihf": "4.46.2",
-				"@rollup/rollup-linux-arm-musleabihf": "4.46.2",
-				"@rollup/rollup-linux-arm64-gnu": "4.46.2",
-				"@rollup/rollup-linux-arm64-musl": "4.46.2",
-				"@rollup/rollup-linux-loongarch64-gnu": "4.46.2",
-				"@rollup/rollup-linux-ppc64-gnu": "4.46.2",
-				"@rollup/rollup-linux-riscv64-gnu": "4.46.2",
-				"@rollup/rollup-linux-riscv64-musl": "4.46.2",
-				"@rollup/rollup-linux-s390x-gnu": "4.46.2",
-				"@rollup/rollup-linux-x64-gnu": "4.46.2",
-				"@rollup/rollup-linux-x64-musl": "4.46.2",
-				"@rollup/rollup-win32-arm64-msvc": "4.46.2",
-				"@rollup/rollup-win32-ia32-msvc": "4.46.2",
-				"@rollup/rollup-win32-x64-msvc": "4.46.2",
+				"@rollup/rollup-android-arm-eabi": "4.60.2",
+				"@rollup/rollup-android-arm64": "4.60.2",
+				"@rollup/rollup-darwin-arm64": "4.60.2",
+				"@rollup/rollup-darwin-x64": "4.60.2",
+				"@rollup/rollup-freebsd-arm64": "4.60.2",
+				"@rollup/rollup-freebsd-x64": "4.60.2",
+				"@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+				"@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+				"@rollup/rollup-linux-arm64-gnu": "4.60.2",
+				"@rollup/rollup-linux-arm64-musl": "4.60.2",
+				"@rollup/rollup-linux-loong64-gnu": "4.60.2",
+				"@rollup/rollup-linux-loong64-musl": "4.60.2",
+				"@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+				"@rollup/rollup-linux-ppc64-musl": "4.60.2",
+				"@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+				"@rollup/rollup-linux-riscv64-musl": "4.60.2",
+				"@rollup/rollup-linux-s390x-gnu": "4.60.2",
+				"@rollup/rollup-linux-x64-gnu": "4.60.2",
+				"@rollup/rollup-linux-x64-musl": "4.60.2",
+				"@rollup/rollup-openbsd-x64": "4.60.2",
+				"@rollup/rollup-openharmony-arm64": "4.60.2",
+				"@rollup/rollup-win32-arm64-msvc": "4.60.2",
+				"@rollup/rollup-win32-ia32-msvc": "4.60.2",
+				"@rollup/rollup-win32-x64-gnu": "4.60.2",
+				"@rollup/rollup-win32-x64-msvc": "4.60.2",
 				"fsevents": "~2.3.2"
 			}
 		},
@@ -3788,9 +3890,9 @@
 			}
 		},
 		"node_modules/sucrase/node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3819,13 +3921,13 @@
 			}
 		},
 		"node_modules/sucrase/node_modules/minimatch": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"brace-expansion": "^2.0.1"
+				"brace-expansion": "^2.0.2"
 			},
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
@@ -3863,9 +3965,9 @@
 			}
 		},
 		"node_modules/test-exclude/node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3894,13 +3996,13 @@
 			}
 		},
 		"node_modules/test-exclude/node_modules/minimatch": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"brace-expansion": "^2.0.1"
+				"brace-expansion": "^2.0.2"
 			},
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
@@ -4127,7 +4229,6 @@
 			"integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -4176,11 +4277,10 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "7.3.1",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-			"integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+			"version": "7.3.2",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+			"integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.27.0",
 				"fdir": "^6.5.0",
@@ -4736,7 +4836,6 @@
 			"integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/chai": "^5.2.2",
 				"@vitest/expect": "3.2.4",

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import {
 	HtmlProcessor,
 	installSriRuntime,
 	IntegrityProcessor,
+	ManifestProcessor,
 	validateGenerateBundleInputs,
 } from "./internal";
 
@@ -211,6 +212,21 @@ export default function sri(options: SriPluginOptions = {}): PluginOption {
 						dynamicChunkFiles
 					);
 
+					// Step 5: Inject SRI integrity into Vite manifest(s), if emitted.
+					// Purely additive — no-op when build.manifest is disabled.
+					logger.info("Injecting SRI integrity into Vite manifest (if present)");
+					const manifestProcessor = new ManifestProcessor(logger);
+					const manifestResult = manifestProcessor.injectIntegrity(
+						bundle,
+						sriByPathname,
+						skipResources
+					);
+					if (manifestResult.processedFiles > 0) {
+						logger.info(
+							`Manifest integrity: ${manifestResult.augmentedEntries} entr(ies) updated across ${manifestResult.processedFiles} manifest file(s)`
+						);
+					}
+
 					const assetCount = Object.keys(sriByPathname).length;
 					const htmlCount = Object.values(bundle).filter(
 						(item) =>
@@ -218,8 +234,12 @@ export default function sri(options: SriPluginOptions = {}): PluginOption {
 						typeof item.fileName === "string" &&
 						item.fileName.endsWith(".html")
 					).length;
+					const manifestSummary =
+						manifestResult.processedFiles > 0
+							? `, ${manifestResult.processedFiles} manifest file(s) updated`
+							: "";
 					logger.summary(
-						`SRI generation completed: ${assetCount} asset(s) processed, ${htmlCount} HTML file(s) updated`
+						`SRI generation completed: ${assetCount} asset(s) processed, ${htmlCount} HTML file(s) updated${manifestSummary}`
 					);
 				} catch (error) {
 					handleGenerateBundleError(error, logger);

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,18 +115,44 @@ export default function sri(options: SriPluginOptions = {}): PluginOption {
 				logger = createLogger(this, verboseLogging);
 
 				try {
-					// Step 1: Validate inputs and early return conditions
+					// Step 1: Validate inputs. Emit any validation warning (e.g. the
+					// SSR-no-HTML diagnostic) but only short-circuit the entire handler
+					// when there is genuinely nothing to do — neither HTML nor a Vite
+					// manifest to augment. Processing a manifest with no HTML is the
+					// primary target of issue #23 (backend-owned HTML generation).
 					const validationResult = validateGenerateBundleInputs(
 						bundle,
 						isSSR
 					);
-					if (!validationResult.isValid) {
-						if (
-							validationResult.shouldWarn &&
-							validationResult.message
-						) {
-							logger.warn(validationResult.message);
-						}
+					if (
+						validationResult.shouldWarn &&
+						validationResult.message
+					) {
+						logger.warn(validationResult.message);
+					}
+					if (
+						!bundle ||
+						typeof bundle !== "object" ||
+						Object.keys(bundle).length === 0
+					) {
+						return;
+					}
+					const hasHtmlFiles = Object.entries(bundle).some(
+						([fn, item]) =>
+							fn.toLowerCase().endsWith(".html") &&
+							item &&
+							(item as any).type === "asset"
+					);
+					const hasManifestFiles = Object.entries(bundle).some(
+						([fn, item]) =>
+							item &&
+							(item as any).type === "asset" &&
+							fn !== ".vite/ssr-manifest.json" &&
+							fn.endsWith("manifest.json")
+					);
+					// Preserve existing no-op behavior when the bundle produces neither
+					// HTML nor a manifest — nothing for this plugin to do.
+					if (!hasHtmlFiles && !hasManifestFiles) {
 						return;
 					}
 
@@ -191,26 +217,29 @@ export default function sri(options: SriPluginOptions = {}): PluginOption {
 					dynamicChunkFiles =
 						dynamicImportAnalyzer.analyzeDynamicImports(bundle);
 
-					// Step 4: Process HTML files with comprehensive error handling
-					logger.info("Processing HTML files for SRI injection");
-					const htmlProcessor = new HtmlProcessor({
-						algorithm,
-						crossorigin,
-						base,
-						preloadDynamicChunks,
-						enableCache,
-						remoteCache,
-						pending,
-						fetchTimeoutMs,
-						logger,
-						skipResources,
-					});
+					// Step 4: Process HTML files with comprehensive error handling.
+					// Skipped when the bundle emits no HTML (e.g. backend-owned HTML generation).
+					if (hasHtmlFiles) {
+						logger.info("Processing HTML files for SRI injection");
+						const htmlProcessor = new HtmlProcessor({
+							algorithm,
+							crossorigin,
+							base,
+							preloadDynamicChunks,
+							enableCache,
+							remoteCache,
+							pending,
+							fetchTimeoutMs,
+							logger,
+							skipResources,
+						});
 
-					await htmlProcessor.processHtmlFiles(
-						bundle,
-						sriByPathname,
-						dynamicChunkFiles
-					);
+						await htmlProcessor.processHtmlFiles(
+							bundle,
+							sriByPathname,
+							dynamicChunkFiles
+						);
+					}
 
 					// Step 5: Inject SRI integrity into Vite manifest(s), if emitted.
 					// Purely additive — no-op when build.manifest is disabled.

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -1870,19 +1870,31 @@ export class ManifestProcessor {
 			const raw = this.assetSourceToString(asset.source);
 			if (raw === null) continue;
 
+			const isKnown = this.isKnownManifestName(fileName);
+
 			let parsed: unknown;
 			try {
 				parsed = JSON.parse(raw);
 			} catch (err) {
-				this.logger.warn(
-					`Failed to parse Vite manifest at ${fileName}; leaving untouched. ${
-						err instanceof Error ? err.message : String(err)
-					}`
-				);
+				// For known Vite manifest paths, a parse failure is worth warning about.
+				// For custom *manifest.json assets, stay silent — they may be unrelated
+				// (PWA manifests, plugin-emitted metadata, etc.).
+				if (isKnown) {
+					this.logger.warn(
+						`Failed to parse Vite manifest at ${fileName}; leaving untouched. ${
+							err instanceof Error ? err.message : String(err)
+						}`
+					);
+				}
 				continue;
 			}
 
-			if (!this.isManifestShape(parsed, fileName)) continue;
+			if (!this.isManifestShape(parsed, fileName, isKnown)) continue;
+
+			// For non-known names, require a shape that actually looks like a Vite
+			// build manifest (at least one entry with a string `file`) before we
+			// risk mutating or noisily warning on its contents.
+			if (!isKnown && !this.looksLikeViteManifest(parsed)) continue;
 
 			const count = this.augmentManifest(
 				parsed,
@@ -1894,8 +1906,8 @@ export class ManifestProcessor {
 			if (count > 0) {
 				asset.source = JSON.stringify(parsed, null, 2);
 				augmentedEntries += count;
+				processedFiles++;
 			}
-			processedFiles++;
 		}
 
 		return { processedFiles, augmentedEntries };
@@ -1904,8 +1916,14 @@ export class ManifestProcessor {
 	private isManifestCandidate(fileName: string): boolean {
 		if (fileName === ManifestProcessor.SSR_MANIFEST_NAME) return false;
 		if (ManifestProcessor.KNOWN_MANIFEST_NAMES.has(fileName)) return true;
-		// Accept custom names ending in manifest.json (user-configured build.manifest string)
+		// Accept custom names ending in manifest.json (user-configured build.manifest string).
+		// Strict shape validation in looksLikeViteManifest ensures non-Vite manifests
+		// (PWA, Webpack, arbitrary plugin output) are silently ignored.
 		return fileName.endsWith("manifest.json");
+	}
+
+	private isKnownManifestName(fileName: string): boolean {
+		return ManifestProcessor.KNOWN_MANIFEST_NAMES.has(fileName);
 	}
 
 	private assetSourceToString(source: unknown): string | null {
@@ -1922,15 +1940,37 @@ export class ManifestProcessor {
 
 	private isManifestShape(
 		manifest: unknown,
-		fileName: string
+		fileName: string,
+		isKnown: boolean
 	): manifest is ViteManifest {
 		if (!manifest || typeof manifest !== "object" || Array.isArray(manifest)) {
-			this.logger.warn(
-				`Vite manifest at ${fileName} is not a plain object; skipping integrity injection.`
-			);
+			if (isKnown) {
+				this.logger.warn(
+					`Vite manifest at ${fileName} is not a plain object; skipping integrity injection.`
+				);
+			}
 			return false;
 		}
 		return true;
+	}
+
+	/**
+	 * Duck-type check: true if the object looks like a Vite build manifest
+	 * (at least one own-property value is an object with a string `file`).
+	 * Used to filter out unrelated *manifest.json assets emitted by other plugins.
+	 */
+	private looksLikeViteManifest(manifest: ViteManifest): boolean {
+		for (const value of Object.values(manifest)) {
+			if (
+				value &&
+				typeof value === "object" &&
+				!Array.isArray(value) &&
+				typeof (value as ViteManifestEntry).file === "string"
+			) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	private augmentManifest(

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -1806,6 +1806,225 @@ export class HtmlProcessor {
 // #endregion
 
 // =======================================================
+// #region MANIFEST PROCESSING
+// =======================================================
+
+/**
+ * Minimal recognized shape of a Vite manifest entry. Any unrecognized fields
+ * are preserved untouched during augmentation.
+ */
+type ViteManifestEntry = {
+	file: string;
+	css?: string[];
+	integrity?: string;
+	cssIntegrity?: Array<string | null>;
+	[key: string]: unknown;
+};
+
+type ViteManifest = Record<string, ViteManifestEntry>;
+
+/**
+ * Injects SRI integrity values into Vite-emitted manifest.json files.
+ *
+ * Behavior:
+ * - Purely additive: augments entries with `integrity` (for `file`) and
+ *   `cssIntegrity` (parallel array for `css`). Non-matching entries remain
+ *   unchanged.
+ * - Skips `.vite/ssr-manifest.json` (different schema).
+ * - Honors skipResources patterns — files matching a pattern get no integrity.
+ * - Never overwrites an existing `integrity`/`cssIntegrity` value.
+ * - On JSON parse failure or unexpected shape, warns and leaves the asset alone.
+ */
+export class ManifestProcessor {
+	private static readonly KNOWN_MANIFEST_NAMES: ReadonlySet<string> = new Set([
+		".vite/manifest.json",
+		"manifest.json",
+	]);
+	private static readonly SSR_MANIFEST_NAME = ".vite/ssr-manifest.json";
+
+	constructor(private readonly logger: BundleLogger) {}
+
+	/**
+	 * Finds every Vite-style manifest asset in the bundle and augments each
+	 * entry with an integrity value (for the primary `file`) and a parallel
+	 * `cssIntegrity` array (for the `css` array, when present).
+	 *
+	 * @param bundle Rollup OutputBundle
+	 * @param sriByPathname Map of pathnames (with leading `/`) to SRI hashes
+	 * @param skipResources skipResources patterns — matching files get no integrity
+	 * @returns counts of manifest files processed and entries augmented
+	 */
+	injectIntegrity(
+		bundle: OutputBundle,
+		sriByPathname: Record<string, string>,
+		skipResources: string[]
+	): { processedFiles: number; augmentedEntries: number } {
+		let processedFiles = 0;
+		let augmentedEntries = 0;
+
+		for (const [fileName, bundleItem] of Object.entries(bundle)) {
+			if (bundleItem.type !== "asset") continue;
+			if (!this.isManifestCandidate(fileName)) continue;
+
+			const asset = bundleItem as OutputAsset;
+			const raw = this.assetSourceToString(asset.source);
+			if (raw === null) continue;
+
+			let parsed: unknown;
+			try {
+				parsed = JSON.parse(raw);
+			} catch (err) {
+				this.logger.warn(
+					`Failed to parse Vite manifest at ${fileName}; leaving untouched. ${
+						err instanceof Error ? err.message : String(err)
+					}`
+				);
+				continue;
+			}
+
+			if (!this.isManifestShape(parsed, fileName)) continue;
+
+			const count = this.augmentManifest(
+				parsed,
+				sriByPathname,
+				skipResources,
+				fileName
+			);
+
+			if (count > 0) {
+				asset.source = JSON.stringify(parsed, null, 2);
+				augmentedEntries += count;
+			}
+			processedFiles++;
+		}
+
+		return { processedFiles, augmentedEntries };
+	}
+
+	private isManifestCandidate(fileName: string): boolean {
+		if (fileName === ManifestProcessor.SSR_MANIFEST_NAME) return false;
+		if (ManifestProcessor.KNOWN_MANIFEST_NAMES.has(fileName)) return true;
+		// Accept custom names ending in manifest.json (user-configured build.manifest string)
+		return fileName.endsWith("manifest.json");
+	}
+
+	private assetSourceToString(source: unknown): string | null {
+		if (typeof source === "string") return source;
+		if (source instanceof Uint8Array) {
+			try {
+				return new TextDecoder().decode(source);
+			} catch {
+				return null;
+			}
+		}
+		return null;
+	}
+
+	private isManifestShape(
+		manifest: unknown,
+		fileName: string
+	): manifest is ViteManifest {
+		if (!manifest || typeof manifest !== "object" || Array.isArray(manifest)) {
+			this.logger.warn(
+				`Vite manifest at ${fileName} is not a plain object; skipping integrity injection.`
+			);
+			return false;
+		}
+		return true;
+	}
+
+	private augmentManifest(
+		manifest: ViteManifest,
+		sriByPathname: Record<string, string>,
+		skipResources: string[],
+		fileName: string
+	): number {
+		let augmented = 0;
+		for (const [key, entry] of Object.entries(manifest)) {
+			if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+				this.logger.warn(
+					`Skipping manifest entry "${key}" in ${fileName}: not an object.`
+				);
+				continue;
+			}
+			if (typeof (entry as ViteManifestEntry).file !== "string") {
+				this.logger.warn(
+					`Skipping manifest entry "${key}" in ${fileName}: missing string "file".`
+				);
+				continue;
+			}
+
+			let touched = false;
+
+			// Primary file integrity (never overwrite existing)
+			if (typeof entry.integrity !== "string") {
+				const hash = this.lookupHash(
+					entry.file,
+					sriByPathname,
+					skipResources
+				);
+				if (hash) {
+					entry.integrity = hash;
+					touched = true;
+				}
+			}
+
+			// Parallel cssIntegrity array (never overwrite existing)
+			if (
+				Array.isArray(entry.css) &&
+				entry.css.length > 0 &&
+				!Array.isArray(entry.cssIntegrity)
+			) {
+				const cssIntegrity: Array<string | null> = [];
+				let haveAny = false;
+				for (const cssFile of entry.css) {
+					if (typeof cssFile !== "string") {
+						cssIntegrity.push(null);
+						continue;
+					}
+					const hash = this.lookupHash(
+						cssFile,
+						sriByPathname,
+						skipResources
+					);
+					cssIntegrity.push(hash ?? null);
+					if (hash) haveAny = true;
+				}
+				if (haveAny) {
+					entry.cssIntegrity = cssIntegrity;
+					touched = true;
+				}
+			}
+
+			if (touched) augmented++;
+		}
+		return augmented;
+	}
+
+	private lookupHash(
+		file: string,
+		sriByPathname: Record<string, string>,
+		skipResources: string[]
+	): string | undefined {
+		if (this.isSkipped(file, skipResources)) return undefined;
+		const key = file.startsWith("/") ? file : `/${file}`;
+		return sriByPathname[key];
+	}
+
+	private isSkipped(file: string, skipResources: string[]): boolean {
+		if (!skipResources || skipResources.length === 0) return false;
+		for (const pattern of skipResources) {
+			if (matchesPattern(pattern, file)) return true;
+			// Also allow patterns written with a leading slash to match
+			if (matchesPattern(pattern, `/${file}`)) return true;
+		}
+		return false;
+	}
+}
+
+// #endregion
+
+// =======================================================
 // #region RUNTIME SRI INJECTION
 // =======================================================
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1923,4 +1923,135 @@ describe("vite-plugin-sri-gen", () => {
 			);
 		});
 	});
+
+	describe("Vite Manifest Integration", () => {
+		it("injects integrity into an emitted .vite/manifest.json", async () => {
+			const plugin = sri({ algorithm: "sha256" }) as any;
+			const manifest = {
+				"src/main.tsx": {
+					file: "assets/main.js",
+					src: "src/main.tsx",
+					isEntry: true,
+					css: ["assets/main.css"],
+				},
+			};
+			const bundle: any = {
+				"index.html": {
+					type: "asset",
+					source: "<!doctype html><html><head></head><body></body></html>",
+				},
+				"assets/main.js": {
+					type: "chunk",
+					fileName: "assets/main.js",
+					code: "console.log('main')",
+				},
+				"assets/main.css": {
+					type: "asset",
+					fileName: "assets/main.css",
+					source: "body{color:red}",
+				},
+				".vite/manifest.json": {
+					type: "asset",
+					fileName: ".vite/manifest.json",
+					source: JSON.stringify(manifest),
+				},
+			};
+
+			await plugin.generateBundle.handler({}, bundle);
+
+			const updated = JSON.parse(String(bundle[".vite/manifest.json"].source));
+			expect(updated["src/main.tsx"].integrity).toMatch(/^sha256-/);
+			expect(Array.isArray(updated["src/main.tsx"].cssIntegrity)).toBe(true);
+			expect(updated["src/main.tsx"].cssIntegrity[0]).toMatch(/^sha256-/);
+			// Preserves unrelated fields
+			expect(updated["src/main.tsx"].isEntry).toBe(true);
+		});
+
+		it("mentions manifest count in the completion summary", async () => {
+			const mockContext = createMockPluginContext();
+			const plugin = sri({ algorithm: "sha256" }) as any;
+			const manifest = {
+				"src/main.tsx": { file: "assets/main.js" },
+			};
+			const bundle: any = {
+				"index.html": {
+					type: "asset",
+					source: "<!doctype html><html><head></head><body></body></html>",
+				},
+				"assets/main.js": {
+					type: "chunk",
+					fileName: "assets/main.js",
+					code: "console.log('main')",
+				},
+				".vite/manifest.json": {
+					type: "asset",
+					fileName: ".vite/manifest.json",
+					source: JSON.stringify(manifest),
+				},
+			};
+
+			await plugin.generateBundle.handler.call(mockContext, {}, bundle);
+
+			expect(mockContext.info).toHaveBeenCalledWith(
+				expect.stringContaining("manifest file(s) updated")
+			);
+		});
+
+		it("is a no-op when build.manifest is off (no manifest asset present)", async () => {
+			const plugin = sri({ algorithm: "sha256" }) as any;
+			const bundle: any = {
+				"index.html": {
+					type: "asset",
+					source: "<!doctype html><html><head></head><body></body></html>",
+				},
+				"assets/main.js": {
+					type: "chunk",
+					fileName: "assets/main.js",
+					code: "console.log('main')",
+				},
+			};
+
+			// Should not throw and should leave bundle keys unchanged
+			await plugin.generateBundle.handler({}, bundle);
+			expect(Object.keys(bundle)).toEqual(["index.html", "assets/main.js"]);
+		});
+
+		it("honors skipResources when injecting manifest integrity", async () => {
+			const plugin = sri({
+				algorithm: "sha256",
+				skipResources: ["assets/main.js"],
+			}) as any;
+			const manifest = {
+				"src/main.tsx": { file: "assets/main.js" },
+				"_shared.js": { file: "_shared.js" },
+			};
+			const bundle: any = {
+				"index.html": {
+					type: "asset",
+					source: "<!doctype html><html><head></head><body></body></html>",
+				},
+				"assets/main.js": {
+					type: "chunk",
+					fileName: "assets/main.js",
+					code: "console.log('main')",
+				},
+				"_shared.js": {
+					type: "chunk",
+					fileName: "_shared.js",
+					code: "export {}",
+				},
+				".vite/manifest.json": {
+					type: "asset",
+					fileName: ".vite/manifest.json",
+					source: JSON.stringify(manifest),
+				},
+			};
+
+			await plugin.generateBundle.handler({}, bundle);
+
+			const updated = JSON.parse(String(bundle[".vite/manifest.json"].source));
+			expect(updated["src/main.tsx"].integrity).toBeUndefined();
+			expect(updated["_shared.js"].integrity).toMatch(/^sha256-/);
+		});
+	});
 });

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -2016,6 +2016,46 @@ describe("vite-plugin-sri-gen", () => {
 			expect(Object.keys(bundle)).toEqual(["index.html", "assets/main.js"]);
 		});
 
+		it("injects manifest integrity even when the bundle has no HTML (backend-owned HTML scenario)", async () => {
+			// This is the primary use case from issue #23: a Vite build configured
+			// with build.manifest: true but no HTML emission, because the backend
+			// renders its own HTML and only needs the manifest.
+			const plugin = sri({ algorithm: "sha256" }) as any;
+			const manifest = {
+				"src/main.tsx": {
+					file: "assets/main.js",
+					src: "src/main.tsx",
+					isEntry: true,
+					css: ["assets/main.css"],
+				},
+			};
+			const bundle: any = {
+				"assets/main.js": {
+					type: "chunk",
+					fileName: "assets/main.js",
+					code: "console.log('main')",
+				},
+				"assets/main.css": {
+					type: "asset",
+					fileName: "assets/main.css",
+					source: "body{color:red}",
+				},
+				".vite/manifest.json": {
+					type: "asset",
+					fileName: ".vite/manifest.json",
+					source: JSON.stringify(manifest),
+				},
+			};
+
+			await plugin.generateBundle.handler({}, bundle);
+
+			const updated = JSON.parse(
+				String(bundle[".vite/manifest.json"].source)
+			);
+			expect(updated["src/main.tsx"].integrity).toMatch(/^sha256-/);
+			expect(updated["src/main.tsx"].cssIntegrity[0]).toMatch(/^sha256-/);
+		});
+
 		it("honors skipResources when injecting manifest integrity", async () => {
 			const plugin = sri({
 				algorithm: "sha256",

--- a/test/internal.spec.ts
+++ b/test/internal.spec.ts
@@ -17,6 +17,7 @@ import {
 	isHttpUrl,
 	joinBaseHref,
 	loadResource,
+	ManifestProcessor,
 	matchesPattern,
 	normalizeBundlePath,
 	processElement,
@@ -1567,6 +1568,312 @@ describe("Processing Classes", () => {
 			expect(mockLogger.warn).toHaveBeenCalledWith(
 				expect.stringContaining("No HTML files found in bundle")
 			);
+		});
+	});
+
+	describe("ManifestProcessor", () => {
+		const SRI_JS_MAIN = "sha384-MAINJS";
+		const SRI_CSS = "sha384-MAINCSS";
+		const SRI_SHARED = "sha384-SHARED";
+
+		const makeManifestAsset = (fileName: string, manifest: unknown) => ({
+			type: "asset" as const,
+			fileName,
+			source: JSON.stringify(manifest),
+		});
+
+		const defaultSriMap = (): Record<string, string> => ({
+			"/assets/main-XYZ.js": SRI_JS_MAIN,
+			"/assets/main-ABC.css": SRI_CSS,
+			"/_shared-GHI.js": SRI_SHARED,
+		});
+
+		const defaultManifest = () => ({
+			"src/main.tsx": {
+				file: "assets/main-XYZ.js",
+				src: "src/main.tsx",
+				isEntry: true,
+				css: ["assets/main-ABC.css"],
+				imports: ["_shared-GHI.js"],
+			},
+			"_shared-GHI.js": {
+				file: "_shared-GHI.js",
+			},
+		});
+
+		it("is a no-op when the bundle contains no manifest", () => {
+			const logger = createMockBundleLogger();
+			const processor = new ManifestProcessor(logger);
+			const bundle: any = {
+				"index.html": { type: "asset", fileName: "index.html", source: "<html/>" },
+				"assets/main-XYZ.js": { type: "chunk", fileName: "assets/main-XYZ.js", code: "x" },
+			};
+
+			const result = processor.injectIntegrity(bundle, defaultSriMap(), []);
+
+			expect(result).toEqual({ processedFiles: 0, augmentedEntries: 0 });
+			expect(logger.warn).not.toHaveBeenCalled();
+		});
+
+		it("augments .vite/manifest.json with integrity and cssIntegrity", () => {
+			const logger = createMockBundleLogger();
+			const processor = new ManifestProcessor(logger);
+			const bundle: any = {
+				".vite/manifest.json": makeManifestAsset(".vite/manifest.json", defaultManifest()),
+			};
+
+			const result = processor.injectIntegrity(bundle, defaultSriMap(), []);
+
+			expect(result.processedFiles).toBe(1);
+			expect(result.augmentedEntries).toBe(2);
+
+			const updated = JSON.parse(String(bundle[".vite/manifest.json"].source));
+			expect(updated["src/main.tsx"].integrity).toBe(SRI_JS_MAIN);
+			expect(updated["src/main.tsx"].cssIntegrity).toEqual([SRI_CSS]);
+			expect(updated["_shared-GHI.js"].integrity).toBe(SRI_SHARED);
+
+			// Preserves unrelated fields
+			expect(updated["src/main.tsx"].isEntry).toBe(true);
+			expect(updated["src/main.tsx"].imports).toEqual(["_shared-GHI.js"]);
+		});
+
+		it("augments legacy manifest.json filename", () => {
+			const logger = createMockBundleLogger();
+			const processor = new ManifestProcessor(logger);
+			const bundle: any = {
+				"manifest.json": makeManifestAsset("manifest.json", defaultManifest()),
+			};
+
+			const result = processor.injectIntegrity(bundle, defaultSriMap(), []);
+
+			expect(result.processedFiles).toBe(1);
+			const updated = JSON.parse(String(bundle["manifest.json"].source));
+			expect(updated["src/main.tsx"].integrity).toBe(SRI_JS_MAIN);
+		});
+
+		it("honors skipResources for primary file", () => {
+			const logger = createMockBundleLogger();
+			const processor = new ManifestProcessor(logger);
+			const bundle: any = {
+				".vite/manifest.json": makeManifestAsset(
+					".vite/manifest.json",
+					defaultManifest()
+				),
+			};
+
+			processor.injectIntegrity(bundle, defaultSriMap(), [
+				"assets/main-*.js",
+			]);
+
+			const updated = JSON.parse(String(bundle[".vite/manifest.json"].source));
+			expect(updated["src/main.tsx"].integrity).toBeUndefined();
+			// Shared chunk unaffected
+			expect(updated["_shared-GHI.js"].integrity).toBe(SRI_SHARED);
+		});
+
+		it("honors skipResources for individual css entries and emits nulls", () => {
+			const logger = createMockBundleLogger();
+			const processor = new ManifestProcessor(logger);
+			const manifest = {
+				"src/main.tsx": {
+					file: "assets/main-XYZ.js",
+					css: ["assets/main-ABC.css", "assets/extra-DEF.css"],
+				},
+			};
+			const sriMap = {
+				"/assets/main-XYZ.js": SRI_JS_MAIN,
+				"/assets/main-ABC.css": SRI_CSS,
+				"/assets/extra-DEF.css": "sha384-EXTRA",
+			};
+			const bundle: any = {
+				".vite/manifest.json": makeManifestAsset(".vite/manifest.json", manifest),
+			};
+
+			processor.injectIntegrity(bundle, sriMap, ["assets/extra-*"]);
+
+			const updated = JSON.parse(String(bundle[".vite/manifest.json"].source));
+			expect(updated["src/main.tsx"].cssIntegrity).toEqual([SRI_CSS, null]);
+		});
+
+		it("omits cssIntegrity when no css entry has a hash", () => {
+			const logger = createMockBundleLogger();
+			const processor = new ManifestProcessor(logger);
+			const manifest = {
+				"src/main.tsx": {
+					file: "assets/main-XYZ.js",
+					css: ["assets/unknown.css"],
+				},
+			};
+			const bundle: any = {
+				".vite/manifest.json": makeManifestAsset(".vite/manifest.json", manifest),
+			};
+
+			processor.injectIntegrity(
+				bundle,
+				{ "/assets/main-XYZ.js": SRI_JS_MAIN },
+				[]
+			);
+
+			const updated = JSON.parse(String(bundle[".vite/manifest.json"].source));
+			expect(updated["src/main.tsx"].cssIntegrity).toBeUndefined();
+		});
+
+		it("omits integrity when the file is not present in sriByPathname", () => {
+			const logger = createMockBundleLogger();
+			const processor = new ManifestProcessor(logger);
+			const manifest = {
+				"image.png": { file: "assets/image.png" },
+			};
+			const bundle: any = {
+				".vite/manifest.json": makeManifestAsset(".vite/manifest.json", manifest),
+			};
+
+			processor.injectIntegrity(bundle, defaultSriMap(), []);
+
+			const updated = JSON.parse(String(bundle[".vite/manifest.json"].source));
+			expect(updated["image.png"].integrity).toBeUndefined();
+		});
+
+		it("warns and leaves asset untouched when JSON is invalid", () => {
+			const logger = createMockBundleLogger();
+			const processor = new ManifestProcessor(logger);
+			const bundle: any = {
+				".vite/manifest.json": {
+					type: "asset" as const,
+					fileName: ".vite/manifest.json",
+					source: "{ not valid json",
+				},
+			};
+			const original = bundle[".vite/manifest.json"].source;
+
+			const result = processor.injectIntegrity(bundle, defaultSriMap(), []);
+
+			expect(result.processedFiles).toBe(0);
+			expect(bundle[".vite/manifest.json"].source).toBe(original);
+			expect(logger.warn).toHaveBeenCalledWith(
+				expect.stringContaining("Failed to parse Vite manifest")
+			);
+		});
+
+		it("warns when manifest root is not a plain object", () => {
+			const logger = createMockBundleLogger();
+			const processor = new ManifestProcessor(logger);
+			const bundle: any = {
+				".vite/manifest.json": makeManifestAsset(".vite/manifest.json", [1, 2, 3]),
+			};
+
+			const result = processor.injectIntegrity(bundle, defaultSriMap(), []);
+
+			expect(result.processedFiles).toBe(0);
+			expect(logger.warn).toHaveBeenCalledWith(
+				expect.stringContaining("not a plain object")
+			);
+		});
+
+		it("warns per offending entry but keeps processing the rest", () => {
+			const logger = createMockBundleLogger();
+			const processor = new ManifestProcessor(logger);
+			const manifest = {
+				"bad-non-object": "oops",
+				"bad-missing-file": { src: "x" },
+				"ok": { file: "assets/main-XYZ.js" },
+			};
+			const bundle: any = {
+				".vite/manifest.json": makeManifestAsset(".vite/manifest.json", manifest),
+			};
+
+			processor.injectIntegrity(bundle, defaultSriMap(), []);
+
+			const warnMessages = logger.warn.mock.calls.map((c) => c[0]);
+			expect(warnMessages.some((m) => m.includes("bad-non-object"))).toBe(true);
+			expect(warnMessages.some((m) => m.includes("bad-missing-file"))).toBe(true);
+
+			const updated = JSON.parse(String(bundle[".vite/manifest.json"].source));
+			expect(updated["ok"].integrity).toBe(SRI_JS_MAIN);
+		});
+
+		it("ignores .vite/ssr-manifest.json", () => {
+			const logger = createMockBundleLogger();
+			const processor = new ManifestProcessor(logger);
+			const ssrManifest = {
+				"src/main.tsx": ["assets/main-XYZ.js"],
+			};
+			const bundle: any = {
+				".vite/ssr-manifest.json": makeManifestAsset(
+					".vite/ssr-manifest.json",
+					ssrManifest
+				),
+			};
+			const original = bundle[".vite/ssr-manifest.json"].source;
+
+			const result = processor.injectIntegrity(bundle, defaultSriMap(), []);
+
+			expect(result.processedFiles).toBe(0);
+			expect(bundle[".vite/ssr-manifest.json"].source).toBe(original);
+		});
+
+		it("preserves an existing integrity value and does not overwrite", () => {
+			const logger = createMockBundleLogger();
+			const processor = new ManifestProcessor(logger);
+			const manifest = {
+				"src/main.tsx": {
+					file: "assets/main-XYZ.js",
+					integrity: "sha384-PREEXISTING",
+					css: ["assets/main-ABC.css"],
+					cssIntegrity: ["sha384-PREEXISTING-CSS"],
+				},
+			};
+			const bundle: any = {
+				".vite/manifest.json": makeManifestAsset(".vite/manifest.json", manifest),
+			};
+
+			processor.injectIntegrity(bundle, defaultSriMap(), []);
+
+			const updated = JSON.parse(String(bundle[".vite/manifest.json"].source));
+			expect(updated["src/main.tsx"].integrity).toBe("sha384-PREEXISTING");
+			expect(updated["src/main.tsx"].cssIntegrity).toEqual(["sha384-PREEXISTING-CSS"]);
+		});
+
+		it("handles manifest source as Uint8Array", () => {
+			const logger = createMockBundleLogger();
+			const processor = new ManifestProcessor(logger);
+			const bytes = new TextEncoder().encode(JSON.stringify(defaultManifest()));
+			const bundle: any = {
+				".vite/manifest.json": {
+					type: "asset" as const,
+					fileName: ".vite/manifest.json",
+					source: bytes,
+				},
+			};
+
+			const result = processor.injectIntegrity(bundle, defaultSriMap(), []);
+
+			expect(result.processedFiles).toBe(1);
+			// Output is re-serialized as a JSON string
+			const updated = JSON.parse(String(bundle[".vite/manifest.json"].source));
+			expect(updated["src/main.tsx"].integrity).toBe(SRI_JS_MAIN);
+		});
+
+		it("does not rewrite source when no entries match", () => {
+			const logger = createMockBundleLogger();
+			const processor = new ManifestProcessor(logger);
+			const manifest = {
+				"image.png": { file: "assets/image.png" },
+			};
+			const originalSource = JSON.stringify(manifest);
+			const bundle: any = {
+				".vite/manifest.json": {
+					type: "asset" as const,
+					fileName: ".vite/manifest.json",
+					source: originalSource,
+				},
+			};
+
+			const result = processor.injectIntegrity(bundle, defaultSriMap(), []);
+
+			expect(result.processedFiles).toBe(1);
+			expect(result.augmentedEntries).toBe(0);
+			expect(bundle[".vite/manifest.json"].source).toBe(originalSource);
 		});
 	});
 

--- a/test/internal.spec.ts
+++ b/test/internal.spec.ts
@@ -1957,6 +1957,165 @@ describe("Processing Classes", () => {
 			expect(result.augmentedEntries).toBe(0);
 			expect(logger.warn).not.toHaveBeenCalled();
 		});
+
+		it("silently recovers when TextDecoder fails to decode a Uint8Array-like source", () => {
+			const logger = createMockBundleLogger();
+			const processor = new ManifestProcessor(logger);
+			// Object whose prototype chain includes Uint8Array.prototype (so
+			// `instanceof Uint8Array` is true) but which lacks the internal
+			// [[TypedArrayName]] slot, causing TextDecoder.decode to throw.
+			const fakeBuffer = Object.create(Uint8Array.prototype);
+			const bundle: any = {
+				".vite/manifest.json": {
+					type: "asset" as const,
+					fileName: ".vite/manifest.json",
+					source: fakeBuffer,
+				},
+			};
+
+			const result = processor.injectIntegrity(bundle, defaultSriMap(), []);
+
+			expect(result.processedFiles).toBe(0);
+			expect(result.augmentedEntries).toBe(0);
+			expect(logger.warn).not.toHaveBeenCalled();
+		});
+
+		it("stringifies non-Error throws from JSON.parse in the warn message", () => {
+			const logger = createMockBundleLogger();
+			const processor = new ManifestProcessor(logger);
+			const bundle: any = {
+				".vite/manifest.json": {
+					type: "asset" as const,
+					fileName: ".vite/manifest.json",
+					source: "{}",
+				},
+			};
+
+			const originalParse = JSON.parse;
+			JSON.parse = (() => {
+				throw "weird-string-error";
+			}) as any;
+			try {
+				processor.injectIntegrity(bundle, defaultSriMap(), []);
+			} finally {
+				JSON.parse = originalParse;
+			}
+
+			expect(logger.warn).toHaveBeenCalledWith(
+				expect.stringContaining("weird-string-error")
+			);
+		});
+
+		it("silently ignores a custom *manifest.json whose contents fail to parse", () => {
+			const logger = createMockBundleLogger();
+			const processor = new ManifestProcessor(logger);
+			const bundle: any = {
+				"public/app-manifest.json": {
+					type: "asset" as const,
+					fileName: "public/app-manifest.json",
+					source: "{ not valid json",
+				},
+			};
+			const originalSource = bundle["public/app-manifest.json"].source;
+
+			const result = processor.injectIntegrity(bundle, defaultSriMap(), []);
+
+			expect(result.processedFiles).toBe(0);
+			expect(bundle["public/app-manifest.json"].source).toBe(originalSource);
+			expect(logger.warn).not.toHaveBeenCalled();
+		});
+
+		it("silently ignores a custom *manifest.json whose root is not an object", () => {
+			const logger = createMockBundleLogger();
+			const processor = new ManifestProcessor(logger);
+			const bundle: any = {
+				"public/app-manifest.json": makeManifestAsset(
+					"public/app-manifest.json",
+					[1, 2, 3]
+				),
+			};
+
+			const result = processor.injectIntegrity(bundle, defaultSriMap(), []);
+
+			expect(result.processedFiles).toBe(0);
+			expect(logger.warn).not.toHaveBeenCalled();
+		});
+
+		it("skips null and array entries with a warning, processing the rest", () => {
+			const logger = createMockBundleLogger();
+			const processor = new ManifestProcessor(logger);
+			const manifest: any = {
+				"null-entry": null,
+				"array-entry": [1, 2, 3],
+				"ok": { file: "assets/main-XYZ.js" },
+			};
+			const bundle: any = {
+				".vite/manifest.json": makeManifestAsset(".vite/manifest.json", manifest),
+			};
+
+			processor.injectIntegrity(bundle, defaultSriMap(), []);
+
+			const warnMsgs = logger.warn.mock.calls.map((c) => c[0]);
+			expect(warnMsgs.some((m) => m.includes("null-entry"))).toBe(true);
+			expect(warnMsgs.some((m) => m.includes("array-entry"))).toBe(true);
+			const updated = JSON.parse(String(bundle[".vite/manifest.json"].source));
+			expect(updated["ok"].integrity).toBe(SRI_JS_MAIN);
+		});
+
+		it("does not emit cssIntegrity when css is an empty array", () => {
+			const logger = createMockBundleLogger();
+			const processor = new ManifestProcessor(logger);
+			const manifest = {
+				"src/main.tsx": { file: "assets/main-XYZ.js", css: [] as string[] },
+			};
+			const bundle: any = {
+				".vite/manifest.json": makeManifestAsset(".vite/manifest.json", manifest),
+			};
+
+			processor.injectIntegrity(bundle, defaultSriMap(), []);
+
+			const updated = JSON.parse(String(bundle[".vite/manifest.json"].source));
+			expect(updated["src/main.tsx"].cssIntegrity).toBeUndefined();
+			expect(updated["src/main.tsx"].integrity).toBe(SRI_JS_MAIN);
+		});
+
+		it("handles manifest entries whose file already starts with a leading slash", () => {
+			const logger = createMockBundleLogger();
+			const processor = new ManifestProcessor(logger);
+			const manifest = {
+				"src/main.tsx": { file: "/assets/main-XYZ.js" },
+			};
+			const bundle: any = {
+				".vite/manifest.json": makeManifestAsset(".vite/manifest.json", manifest),
+			};
+
+			processor.injectIntegrity(bundle, defaultSriMap(), []);
+
+			const updated = JSON.parse(String(bundle[".vite/manifest.json"].source));
+			expect(updated["src/main.tsx"].integrity).toBe(SRI_JS_MAIN);
+		});
+
+		it("matches skipResources patterns written with a leading slash", () => {
+			const logger = createMockBundleLogger();
+			const processor = new ManifestProcessor(logger);
+			const bundle: any = {
+				".vite/manifest.json": makeManifestAsset(
+					".vite/manifest.json",
+					defaultManifest()
+				),
+			};
+
+			// Pattern intentionally starts with "/" — exercises the fallback
+			// match against "/" + file inside ManifestProcessor.isSkipped.
+			processor.injectIntegrity(bundle, defaultSriMap(), [
+				"/assets/main-*.js",
+			]);
+
+			const updated = JSON.parse(String(bundle[".vite/manifest.json"].source));
+			expect(updated["src/main.tsx"].integrity).toBeUndefined();
+			// Unrelated entries still receive integrity.
+			expect(updated["_shared-GHI.js"].integrity).toBe(SRI_SHARED);
+		});
 	});
 
 	describe("Legacy Coverage Tests (Global Overrides - Consider New Architecture)", () => {

--- a/test/internal.spec.ts
+++ b/test/internal.spec.ts
@@ -1854,7 +1854,7 @@ describe("Processing Classes", () => {
 			expect(updated["src/main.tsx"].integrity).toBe(SRI_JS_MAIN);
 		});
 
-		it("does not rewrite source when no entries match", () => {
+		it("does not rewrite source or count the file when no entries augment", () => {
 			const logger = createMockBundleLogger();
 			const processor = new ManifestProcessor(logger);
 			const manifest = {
@@ -1871,9 +1871,91 @@ describe("Processing Classes", () => {
 
 			const result = processor.injectIntegrity(bundle, defaultSriMap(), []);
 
-			expect(result.processedFiles).toBe(1);
+			expect(result.processedFiles).toBe(0);
 			expect(result.augmentedEntries).toBe(0);
 			expect(bundle[".vite/manifest.json"].source).toBe(originalSource);
+		});
+
+		it("silently ignores a custom *manifest.json that does not look like a Vite manifest", () => {
+			const logger = createMockBundleLogger();
+			const processor = new ManifestProcessor(logger);
+			// PWA-like web-app manifest also named "...manifest.json" — no `file` fields.
+			const pwaManifest = {
+				name: "My App",
+				short_name: "App",
+				icons: [{ src: "/icon.png", sizes: "192x192" }],
+			};
+			const originalSource = JSON.stringify(pwaManifest);
+			const bundle: any = {
+				"public/app-manifest.json": {
+					type: "asset" as const,
+					fileName: "public/app-manifest.json",
+					source: originalSource,
+				},
+			};
+
+			const result = processor.injectIntegrity(bundle, defaultSriMap(), []);
+
+			expect(result.processedFiles).toBe(0);
+			expect(result.augmentedEntries).toBe(0);
+			expect(bundle["public/app-manifest.json"].source).toBe(originalSource);
+			expect(logger.warn).not.toHaveBeenCalled();
+		});
+
+		it("augments a custom-named manifest.json that has Vite manifest shape", () => {
+			const logger = createMockBundleLogger();
+			const processor = new ManifestProcessor(logger);
+			const bundle: any = {
+				"custom-manifest.json": makeManifestAsset(
+					"custom-manifest.json",
+					defaultManifest()
+				),
+			};
+
+			const result = processor.injectIntegrity(bundle, defaultSriMap(), []);
+
+			expect(result.processedFiles).toBe(1);
+			const updated = JSON.parse(String(bundle["custom-manifest.json"].source));
+			expect(updated["src/main.tsx"].integrity).toBe(SRI_JS_MAIN);
+		});
+
+		it("emits null placeholders for non-string entries inside css[]", () => {
+			const logger = createMockBundleLogger();
+			const processor = new ManifestProcessor(logger);
+			const manifest = {
+				"src/main.tsx": {
+					file: "assets/main-XYZ.js",
+					// Simulate a corrupt or unexpected manifest: css contains a non-string.
+					css: ["assets/main-ABC.css", 42, null],
+				},
+			};
+			const bundle: any = {
+				".vite/manifest.json": makeManifestAsset(".vite/manifest.json", manifest),
+			};
+
+			processor.injectIntegrity(bundle, defaultSriMap(), []);
+
+			const updated = JSON.parse(String(bundle[".vite/manifest.json"].source));
+			expect(updated["src/main.tsx"].cssIntegrity).toEqual([SRI_CSS, null, null]);
+		});
+
+		it("silently skips assets whose source is neither string nor Uint8Array", () => {
+			const logger = createMockBundleLogger();
+			const processor = new ManifestProcessor(logger);
+			const bundle: any = {
+				".vite/manifest.json": {
+					type: "asset" as const,
+					fileName: ".vite/manifest.json",
+					// Exotic source type unlikely in practice; asserts defensive path.
+					source: 42 as any,
+				},
+			};
+
+			const result = processor.injectIntegrity(bundle, defaultSriMap(), []);
+
+			expect(result.processedFiles).toBe(0);
+			expect(result.augmentedEntries).toBe(0);
+			expect(logger.warn).not.toHaveBeenCalled();
 		});
 	});
 


### PR DESCRIPTION
### Summary

When Vite emits a build manifest (`build.manifest: true`), the plugin now augments it in place with SRI integrity values. This is aimed at setups where the backend owns HTML generation and reads the manifest to decide which assets to load — the backend can now attach `integrity` to its emitted tags without re-hashing the files.

- Adds `integrity` per entry (primary `file`) and a parallel `cssIntegrity` array for the entry's `css[]`.
- Automatic and purely additive — no new plugin options, no-op when `build.manifest` is off.
- Runs even when the bundle emits no HTML (the common case for backend-rendered pages).
- Honors `skipResources`, preserves existing `integrity`/`cssIntegrity`, leaves `.vite/ssr-manifest.json` alone.
- Recognizes `.vite/manifest.json` and legacy `manifest.json`. Custom names (string `build.manifest`) are also recognized but only augmented when the contents match the Vite manifest shape — so PWA Web App manifests and similar unrelated `*manifest.json` assets are silently ignored.

Augmented entry (fields appended at end):

```json
{
  "src/main.tsx": {
    "file": "assets/main-XYZ.js",
    "src": "src/main.tsx",
    "isEntry": true,
    "css": ["assets/main-ABC.css"],
    "imports": ["_shared-GHI.js"],
    "integrity": "sha384-...",
    "cssIntegrity": ["sha384-..."]
  }
}
```

Closes #23.