### PR TITLE
ci: scope GITHUB_TOKEN to contents:read for build and test workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Build 🏗️
+permissions:
+  contents: read
 on:
   workflow_dispatch:
   pull_request:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Test 🧪
+permissions:
+  contents: read
 on:
   workflow_dispatch:
   pull_request:


### PR DESCRIPTION
Resolves two GitHub code scanning alerts:

> Actions job or workflow does not limit the permissions of the GITHUB_TOKEN. Consider setting an explicit permissions block, using the following as a minimal starting point: {contents: read}

## Summary

- Adds a top-level `permissions: contents: read` block to `.github/workflows/build.yml` and `.github/workflows/test.yml`.
- Both workflows only check out source, install dependencies, and run the build/test scripts, so read-only access to repository contents is sufficient.
- `publish.yml` is unaffected — it already declares an explicit `permissions` block (`id-token: write`, `contents: write`) for npm publishing and its bump-commit push.

## Test plan

- [ ] Confirm code scanning alerts clear once this merges.
- [ ] Re-run Build and Test workflows on this PR; both must pass with the narrower token scope.