### PR TITLE
fix: install dynamic-import SRI runtime in consumer bundles (#30)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -63,6 +63,60 @@ export function rewriteDynamicImports(code: string): string {
 }
 
 /**
+ * Builds the self-contained runtime statement that is prepended to entry
+ * chunks. The runtime is shipped by serializing `installSriRuntime` with
+ * `.toString()` and embedding the source into the consumer's bundle.
+ *
+ * The plugin itself is bundled with esbuild (via tsup), whose `keepNames`
+ * transform can wrap named function expressions in a module-scoped
+ * `__name(fn, "name")` helper. That helper lives at the top of the plugin's
+ * own output — NOT inside the serialized function — so the injected copy
+ * references an `__name` that is undefined in the consumer bundle. Because the
+ * runtime guards its setup in a best-effort `try/catch`, the resulting
+ * `ReferenceError: __name is not defined` is swallowed and
+ * `globalThis.__sriImport` is never installed; every rewritten dynamic import
+ * then fails with "`__sriImport` is not defined" (issue #30).
+ *
+ * To keep the injected runtime correct regardless of how the plugin is
+ * bundled, the serialized function is evaluated inside a wrapper that defines a
+ * local `__name` shim in its lexical scope. `__name` only needs to return its
+ * first argument; the function-name assignment it performs is cosmetic.
+ */
+export function buildSriRuntimeCode(
+	runtime: (
+		sriByPathname: Record<string, string>,
+		opts?: Record<string, unknown>
+	) => void,
+	sriByPathname: Record<string, string>,
+	opts: {
+		crossorigin: "anonymous" | "use-credentials" | undefined;
+		skipResources: string[];
+		enforceDynamicImports: boolean;
+	}
+): string {
+	// `JSON.stringify` does not escape `<` or the U+2028/U+2029 line separators.
+	// The serialized data is embedded as a JS string literal inside code that is
+	// prepended to a chunk, so escape those characters to keep the injected
+	// statement well-formed (and safe if a chunk is ever inlined into HTML).
+	// This only changes the source representation; the parsed runtime values are
+	// identical.
+	const escapeForScript = (json: string): string =>
+		json
+			.replace(/</g, "\\u003c")
+			.replace(/\u2028/g, "\\u2028")
+			.replace(/\u2029/g, "\\u2029");
+	const serializedMap = escapeForScript(JSON.stringify(sriByPathname));
+	const cors = opts.crossorigin ? JSON.stringify(opts.crossorigin) : "false";
+	const serializedSkipPatterns = escapeForScript(
+		JSON.stringify(opts.skipResources)
+	);
+	const args = `${serializedMap}, { crossorigin: ${cors}, skipResources: ${serializedSkipPatterns}, enforceDynamicImports: ${opts.enforceDynamicImports} }`;
+	// Self-containment shim — see the doc comment above for why this is needed.
+	const shim = "var __name=function(fn){return fn;};";
+	return `\n(function(){${shim}return (${runtime.toString()});})()(${args});\n`;
+}
+
+/**
  * Vite plugin to add Subresource Integrity (SRI) attributes to external assets in index.html
  * ESM-only, requires Node 18+ (uses global fetch)
  *
@@ -251,10 +305,15 @@ export default function sri(options: SriPluginOptions = {}): PluginOption {
 						// Step 2b: Inject runtime into entry chunks (BEFORE hashing entry chunks)
 						// The runtime contains hashes for dynamic chunks so they can be verified at load time
 						logger.info("Injecting SRI runtime into entry chunks");
-						const serializedMap = JSON.stringify(nonEntryHashes);
-						const cors = crossorigin ? JSON.stringify(crossorigin) : "false";
-						const serializedSkipPatterns = JSON.stringify(skipResources);
-						const runtimeCode = `\n(${installSriRuntime.toString()})(${serializedMap}, { crossorigin: ${cors}, skipResources: ${serializedSkipPatterns}, enforceDynamicImports: ${enforceDynamicImports} });\n`;
+						const runtimeCode = buildSriRuntimeCode(
+							installSriRuntime,
+							nonEntryHashes,
+							{
+								crossorigin,
+								skipResources,
+								enforceDynamicImports,
+							}
+						);
 
 						for (const [fileName, bundleItem] of Object.entries(bundle)) {
 							if (bundleItem.type === "chunk" && bundleItem.isEntry) {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,5 +1,6 @@
+import vm from "node:vm";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import sri, { rewriteDynamicImports } from "../src/index";
+import sri, { buildSriRuntimeCode, rewriteDynamicImports } from "../src/index";
 import { installSriRuntime, installSriRuntimeWithDeps } from "../src/internal";
 import {
 	createMockPluginContext,
@@ -2354,5 +2355,118 @@ describe("vite-plugin-sri-gen", () => {
 			const actual = "sha256-" + btoa(bin);
 			expect(actual).toBe(expected);
 		});
+	});
+});
+
+describe("buildSriRuntimeCode (issue #30: self-contained injected runtime)", () => {
+	it("installs the global even when the serialized runtime references esbuild's __name helper", () => {
+		// The plugin is bundled with esbuild's keepNames transform, which wraps
+		// named function expressions in a module-scoped `__name(fn, "name")`
+		// helper. That helper is NOT part of `installSriRuntime.toString()`, so
+		// the injected copy references an undefined `__name`. The runtime's
+		// best-effort try/catch then swallows the ReferenceError, leaving
+		// `__sriImport` uninstalled (issue #30). Simulate that exact shape.
+		const runtimeWithKeepNames = function fakeRuntime() {
+			// @ts-expect-error `__name` is injected by esbuild in the real build
+			const tagged = __name(function inner() {}, "inner");
+			(globalThis as any).__sriImport = tagged;
+		} as unknown as typeof installSriRuntime;
+
+		// Control: the raw serialized function throws because `__name` is unbound.
+		const control: any = {};
+		vm.createContext(control);
+		expect(() =>
+			vm.runInContext(`(${runtimeWithKeepNames.toString()})({}, {})`, control)
+		).toThrow(/__name/);
+
+		// buildSriRuntimeCode must make the injected runtime self-contained.
+		const code = buildSriRuntimeCode(
+			runtimeWithKeepNames,
+			{ "/a.js": "sha384-x" },
+			{
+				crossorigin: "anonymous",
+				skipResources: [],
+				enforceDynamicImports: true,
+			}
+		);
+		const sandbox: any = {};
+		vm.createContext(sandbox);
+		expect(() => vm.runInContext(code, sandbox)).not.toThrow();
+		expect(typeof sandbox.__sriImport).toBe("function");
+	});
+
+	it("installs globalThis.__sriImport from the real runtime when enforcement is enabled", () => {
+		// Positive/smoke test for the real runtime. Note: vitest transforms `src`
+		// without esbuild's keepNames, so the real `installSriRuntime.toString()`
+		// here contains no `__name`; this test therefore passes with or without
+		// the shim. The preceding test (synthetic `__name`) is the actual
+		// regression guard for issue #30.
+		const code = buildSriRuntimeCode(
+			installSriRuntime,
+			{ "/chunk.js": "sha384-abc" },
+			{
+				crossorigin: "anonymous",
+				skipResources: [],
+				enforceDynamicImports: true,
+			}
+		);
+		// Minimal DOM constructors so the runtime's post-install patching has
+		// prototypes to wrap. They are deliberately incomplete; any DOM-patch
+		// error after install is swallowed by the runtime's try/catch, and the
+		// assertion below only checks that `__sriImport` was installed (which
+		// happens before the DOM patching).
+		function El(this: any) {}
+		El.prototype.setAttribute = function () {};
+		function NodeCtor(this: any) {}
+		NodeCtor.prototype = {};
+		const sandbox: any = {
+			Element: El,
+			Node: NodeCtor,
+			HTMLLinkElement: function Link(this: any) {},
+			HTMLScriptElement: function Script(this: any) {},
+		};
+		vm.createContext(sandbox);
+		expect(() => vm.runInContext(code, sandbox)).not.toThrow();
+		expect(typeof sandbox.__sriImport).toBe("function");
+	});
+
+	it("preserves the runtime arguments and the installSriRuntime source", () => {
+		const code = buildSriRuntimeCode(
+			installSriRuntime,
+			{ "/a.js": "sha384-x" },
+			{
+				crossorigin: "use-credentials",
+				skipResources: ["analytics-*"],
+				enforceDynamicImports: false,
+			}
+		);
+		expect(code).toContain("installSriRuntime");
+		expect(code).toContain('crossorigin: "use-credentials"');
+		expect(code).toContain('skipResources: ["analytics-*"]');
+		expect(code).toContain("enforceDynamicImports: false");
+		expect(code).toContain('{"/a.js":"sha384-x"}');
+	});
+
+	it("escapes `<` in serialized data so it cannot break out of the injected script", () => {
+		const code = buildSriRuntimeCode(
+			installSriRuntime,
+			{ "/a</script>b.js": "sha384-x", "/normal path.js": "sha384-y" },
+			{
+				crossorigin: undefined,
+				skipResources: ["x<y"],
+				enforceDynamicImports: true,
+			}
+		);
+		// `<` is rewritten to its < escape; the raw sequence must not survive.
+		expect(code).not.toContain("</script>");
+		expect(code).toContain("\\u003c/script>");
+		expect(code).toContain("x\\u003cy");
+		// Non-`<` content (spaces, slashes) is left untouched.
+		expect(code).toContain("/normal path.js");
+		// The escape is the standard JS form, so the runtime parses it back to `<`.
+		const sandbox: any = {};
+		vm.createContext(sandbox);
+		vm.runInContext('globalThis.r = "\\u003c/script>";', sandbox);
+		expect(sandbox.r).toBe("</script>");
 	});
 });

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -12,5 +12,11 @@ export default defineConfig({
   splitting: false,
   sourcemap: true,
   bundle: true,
-  keepNames: true,
+  // keepNames is intentionally disabled: esbuild's keepNames transform injects
+  // a module-scoped `__name` helper into named function expressions. Because
+  // `installSriRuntime` is shipped to consumer bundles via `.toString()`, those
+  // `__name(...)` references would be undefined in the consumer and break the
+  // injected runtime (issue #30). The build is unminified, so keepNames has no
+  // benefit here anyway. buildSriRuntimeCode() also shims `__name` defensively.
+  keepNames: false,
 })


### PR DESCRIPTION
## Summary

Fixes #30 — with the 1.5.0 dynamic-import enforcement, lazy-loaded modules (`import.meta.glob`, `React.lazy`, etc.) failed at runtime with **`__sriImport is not defined`**, so SRI was not enforced for dynamic imports.

## Root cause

The runtime is shipped by serializing `installSriRuntime` via `.toString()` and prepending it to entry chunks. tsup's `keepNames: true` made esbuild wrap named function expressions inside the runtime with a **module-scoped `__name(fn, "name")` helper**. That helper's *definition* lives at the top of the plugin's own bundle and does **not** travel with `.toString()`.

In the consumer bundle `__name` is therefore undefined. The first wrapped helper throws `ReferenceError: __name is not defined` — *before* the `globalThis.__sriImport = …` install line — and the runtime's outer best-effort `try/catch` **swallows** it. `__sriImport` is never installed, so every rewritten `import()` → `__sriImport(…)` call fails.

The reporter's "ordering / var-hoisting" hypothesis was a misdiagnosis: the IIFE *does* run first, but throws internally.

## Changes

- **`tsup.config.ts`**: disable `keepNames` — it injected the leaked `__name` helper and provides no benefit in an unminified build. Verified: the built `dist` now emits **0 `__name(` call sites**.
- **`src/index.ts`**: extract `buildSriRuntimeCode()`, which wraps the serialized runtime in an IIFE that defines a local `__name` shim. This keeps the injected runtime **self-contained regardless of how the plugin is bundled** (defense in depth).
- **`src/index.ts`**: escape `<` (→ `\u003c`) and U+2028/U+2029 in the serialized data embedded in the injected script — behavior-preserving hardening so crafted asset paths/skip patterns can't break out of the injected statement.
- **`test/index.spec.ts`**: regression tests — a fail-first test reproducing the `__name` leak via a synthetic keepNames-shaped runtime, a positive real-runtime install test, an arguments/source preservation test, and a `<` escaping test.

## Testing

- `npm test`: **387 passing**
- `npm run lint`: clean
- `npm run build`: success
- End-to-end against the **built `dist` artifact**: `buildSriRuntimeCode` installs `globalThis.__sriImport` (shim neutralizes `__name`) and escapes `</script>`.

`package.json` is intentionally left at 1.5.0 (the release workflow handles version bumps).
