### PR TITLE
fix: resolve dynamic import specifiers against the importing module URL (#32)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -90,6 +90,11 @@ export function rewriteDynamicImports(code: string): string {
  * bundled, the serialized function is evaluated inside a wrapper that defines a
  * local `__name` shim in its lexical scope. `__name` only needs to return its
  * first argument; the function-name assignment it performs is cosmetic.
+ *
+ * `opts.base` is the resolved Vite `base` (defaults to "/"). It is forwarded
+ * to the runtime so integrity lookups can strip the base prefix from URLs
+ * observed at runtime — the integrity map keys are '/'-rooted bundle file
+ * names that never include the base.
  */
 export function buildSriRuntimeCode(
 	runtime: (

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,15 +51,24 @@ const DYNAMIC_IMPORT_CALL_RE = /(?<![.\w$])import\s*\(/g;
 
 /**
  * Rewrites every dynamic `import(...)` call expression in a chunk to
- * `__sriImport(...)` so the runtime-injected JS-level verifier can enforce
- * integrity before executing the module. The original `import(` syntax inside
- * the runtime itself is preserved because the runtime is concatenated AFTER
- * this rewrite step.
+ * `__sriImport(import.meta.url, ...)` so the runtime-injected JS-level
+ * verifier can enforce integrity before executing the module. The original
+ * `import(` syntax inside the runtime itself is preserved because the runtime
+ * is concatenated AFTER this rewrite step.
+ *
+ * `import.meta.url` is threaded through as the first argument because native
+ * `import()` resolves relative specifiers against the IMPORTING MODULE's URL,
+ * not the document URL. Rollup emits inter-chunk dynamic imports as
+ * module-relative specifiers (e.g. `import('./asset.js')` from a chunk in
+ * `assets/js/`), so without the importer's URL the runtime would resolve the
+ * specifier against `location.href` and look up the wrong pathname
+ * (issue #32). The injected `import.meta.url` text is never re-matched by the
+ * rewrite regex: `import` there is followed by `.`, not `(`.
  */
 export function rewriteDynamicImports(code: string): string {
 	if (!code || typeof code !== "string") return code;
 	if (code.indexOf("import") === -1) return code;
-	return code.replace(DYNAMIC_IMPORT_CALL_RE, "__sriImport(");
+	return code.replace(DYNAMIC_IMPORT_CALL_RE, "__sriImport(import.meta.url, ");
 }
 
 /**
@@ -92,6 +101,7 @@ export function buildSriRuntimeCode(
 		crossorigin: "anonymous" | "use-credentials" | undefined;
 		skipResources: string[];
 		enforceDynamicImports: boolean;
+		base?: string;
 	}
 ): string {
 	// `JSON.stringify` does not escape `<` or the U+2028/U+2029 line separators.
@@ -110,7 +120,8 @@ export function buildSriRuntimeCode(
 	const serializedSkipPatterns = escapeForScript(
 		JSON.stringify(opts.skipResources)
 	);
-	const args = `${serializedMap}, { crossorigin: ${cors}, skipResources: ${serializedSkipPatterns}, enforceDynamicImports: ${opts.enforceDynamicImports} }`;
+	const serializedBase = escapeForScript(JSON.stringify(opts.base ?? "/"));
+	const args = `${serializedMap}, { crossorigin: ${cors}, skipResources: ${serializedSkipPatterns}, enforceDynamicImports: ${opts.enforceDynamicImports}, base: ${serializedBase} }`;
 	// Self-containment shim — see the doc comment above for why this is needed.
 	const shim = "var __name=function(fn){return fn;};";
 	return `\n(function(){${shim}return (${runtime.toString()});})()(${args});\n`;
@@ -312,6 +323,7 @@ export default function sri(options: SriPluginOptions = {}): PluginOption {
 								crossorigin,
 								skipResources,
 								enforceDynamicImports,
+								base,
 							}
 						);
 

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -2352,6 +2352,16 @@ export function installSriRuntime(
 			// resolving against `location.href` yields the wrong pathname
 			// for Rollup's module-relative inter-chunk specifiers like
 			// "./asset.js" (issue #32).
+			//
+			// Residual limitation: verification (`fetch`) and execution
+			// (native `import()`) are two separate requests for the same
+			// resolved URL. The HTTP cache normally makes them coherent, but
+			// a service worker (or a cache-busting intermediary) could in
+			// principle serve different bytes to each. Browsers do not
+			// expose integrity metadata on `import()`, so this TOCTOU window
+			// cannot be fully closed at the JS level — resolving both
+			// requests from one URL (this fix) is the strongest available
+			// guarantee.
 			const sriImport = async function (
 				importerUrl: string | undefined,
 				url: string
@@ -2381,11 +2391,14 @@ export function installSriRuntime(
 							(globalThis as any).location?.href ||
 							undefined
 					);
-				} catch {
+				} catch (e) {
+					// `cause` is ignored by engines that predate ES2022 Error
+					// options; the message alone still identifies the failure.
 					throw new Error(
 						"[vite-plugin-sri-gen] Cannot resolve dynamic import specifier " +
 							url +
-							(importerUrl ? " against " + importerUrl : "")
+							(importerUrl ? " against " + importerUrl : ""),
+						{ cause: e }
 					);
 				}
 				const expected = lookupIntegrityByPathname(resolved.pathname);
@@ -2604,6 +2617,7 @@ export function installSriRuntimeWithDeps(
 	opts?: {
 		crossorigin?: false | "anonymous" | "use-credentials";
 		skipResources?: string[];
+		base?: string;
 	},
 	dependencies: IRuntimeDependencies = defaultDependencies
 ) {
@@ -2667,6 +2681,38 @@ export function installSriRuntimeWithDeps(
 			return false;
 		};
 
+		// Pathname of the configured Vite `base` ("/" when unset) — mirrors
+		// the production `installSriRuntime` so base-stripped lookups behave
+		// identically in both variants.
+		let basePathname = "/";
+		try {
+			const rawBase = opts && (opts as any).base;
+			if (rawBase && typeof rawBase === "string") {
+				basePathname = new URL(rawBase, "http://x/").pathname;
+				if (!basePathname.endsWith("/")) basePathname += "/";
+			}
+		} catch {
+			// Unparseable base (e.g. relative "./") — keep "/" (no stripping)
+		}
+
+		/**
+		 * Looks up an integrity value by URL pathname, retrying with the
+		 * configured base prefix stripped (parity with installSriRuntime).
+		 */
+		const lookupIntegrityByPathname = (
+			pathname: string
+		): string | undefined => {
+			let value = map.get(pathname);
+			if (
+				value === undefined &&
+				basePathname !== "/" &&
+				pathname.indexOf(basePathname) === 0
+			) {
+				value = map.get("/" + pathname.slice(basePathname.length));
+			}
+			return value;
+		};
+
 		/**
 		 * Gets integrity value for a given URL using the URL adapter
 		 */
@@ -2678,7 +2724,7 @@ export function installSriRuntimeWithDeps(
 			try {
 				const resolvedURL = urlAdapter.resolveURL(url);
 				const u = new URL(resolvedURL);
-				return map.get(u.pathname);
+				return lookupIntegrityByPathname(u.pathname);
 			} catch {
 				// URL parsing failed - ignore and return undefined
 				return undefined;

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -2096,6 +2096,7 @@ export function installSriRuntime(
 		crossorigin?: false | "anonymous" | "use-credentials";
 		skipResources?: string[];
 		enforceDynamicImports?: boolean;
+		base?: string;
 	}
 ) {
 	// Sentinel that escapes the outer best-effort catch. Enforcement-install
@@ -2121,6 +2122,42 @@ export function installSriRuntime(
 
 		// Extract skip patterns with default fallback
 		const skipPatterns = (opts && (opts as any).skipResources) || [];
+
+		// Pathname of the configured Vite `base` ("/" when unset). Map keys
+		// are '/'-rooted bundle file names WITHOUT the base prefix, while
+		// URLs observed at runtime include it under sub-path (or CDN-base)
+		// deployments — the lookup helper strips it before retrying.
+		let basePathname = "/";
+		try {
+			const rawBase = opts && (opts as any).base;
+			if (rawBase && typeof rawBase === "string") {
+				basePathname = new URL(rawBase, "http://x/").pathname;
+				if (!basePathname.endsWith("/")) basePathname += "/";
+			}
+		} catch {
+			// Unparseable base (e.g. relative "./") — keep "/" (no stripping)
+		}
+
+		/**
+		 * Looks up an integrity value by URL pathname. Tries the pathname as
+		 * given, then retries with the configured base prefix stripped so a
+		 * key of "/assets/x.js" matches "/app/assets/x.js" when base="/app/".
+		 */
+		const lookupIntegrityByPathname = (
+			pathname: string
+		): string | undefined => {
+			let value = map.get(pathname);
+			if (
+				value === undefined &&
+				basePathname !== "/" &&
+				pathname.indexOf(basePathname) === 0
+			) {
+				value = map.get(
+					"/" + pathname.slice(basePathname.length)
+				);
+			}
+			return value;
+		};
 
 		/**
 		 * Runtime version of pattern matching for skip logic
@@ -2187,7 +2224,7 @@ export function installSriRuntime(
 					url,
 					(globalThis as any).location?.href || ""
 				);
-				value = map.get(u.pathname);
+				value = lookupIntegrityByPathname(u.pathname);
 			} catch {
 				// URL parsing failed - ignore and return undefined
 			}
@@ -2307,7 +2344,18 @@ export function installSriRuntime(
 				}
 				return btoa(binary);
 			};
-			const sriImport = async function (url: string): Promise<any> {
+			// `importerUrl` is the importing module's `import.meta.url`,
+			// threaded through by the build-time rewrite
+			// (`import(x)` -> `__sriImport(import.meta.url, x)`). Native
+			// `import()` resolves relative specifiers against the importing
+			// module's URL, so the runtime must resolve the same way —
+			// resolving against `location.href` yields the wrong pathname
+			// for Rollup's module-relative inter-chunk specifiers like
+			// "./asset.js" (issue #32).
+			const sriImport = async function (
+				importerUrl: string | undefined,
+				url: string
+			): Promise<any> {
 				// Fail closed if the crypto primitive is unavailable. Browsers
 				// only expose crypto.subtle in secure contexts (HTTPS or
 				// localhost). A clear error beats a confusing TypeError.
@@ -2322,11 +2370,32 @@ export function installSriRuntime(
 							": crypto.subtle is unavailable (requires a secure context, e.g. HTTPS or localhost)"
 					);
 				}
-				const expected = getIntegrityForUrl(url);
+				// Resolve the specifier ONCE; the same resolved URL is used
+				// for lookup, fetch, and the native import so the verified
+				// bytes are exactly the executed bytes.
+				let resolved: URL;
+				try {
+					resolved = new URL(
+						url,
+						importerUrl ||
+							(globalThis as any).location?.href ||
+							undefined
+					);
+				} catch {
+					throw new Error(
+						"[vite-plugin-sri-gen] Cannot resolve dynamic import specifier " +
+							url +
+							(importerUrl ? " against " + importerUrl : "")
+					);
+				}
+				const expected = lookupIntegrityByPathname(resolved.pathname);
 				if (!expected) {
 					throw new Error(
 						"[vite-plugin-sri-gen] Refusing dynamic import: no integrity registered for " +
-							url
+							url +
+							" (resolved to " +
+							resolved.href +
+							")"
 					);
 				}
 				const subtleAlgo = subtleAlgoFor(expected);
@@ -2345,11 +2414,11 @@ export function installSriRuntime(
 				const init: any = {};
 				if (cors === "use-credentials") init.credentials = "include";
 				else init.credentials = "same-origin";
-				const response = await fetch(url, init);
+				const response = await fetch(resolved.href, init);
 				if (!response.ok) {
 					throw new Error(
 						"[vite-plugin-sri-gen] Failed to fetch " +
-							url +
+							resolved.href +
 							" for integrity verification (HTTP " +
 							response.status +
 							")"
@@ -2363,7 +2432,7 @@ export function installSriRuntime(
 				if (actual !== expected) {
 					throw new Error(
 						"[vite-plugin-sri-gen] Integrity verification failed for " +
-							url +
+							resolved.href +
 							" (expected " +
 							expected +
 							", got " +
@@ -2373,7 +2442,11 @@ export function installSriRuntime(
 				}
 				// __sriNativeImport is installed below before sriImport is
 				// invoked for the first time, so we can call it directly.
-				return g.__sriNativeImport(url);
+				// Pass the RESOLVED absolute URL: the native import executes
+				// inside the entry chunk, where a relative specifier would
+				// re-resolve against the entry chunk's URL instead of the
+				// original importer's.
+				return g.__sriNativeImport(resolved.href);
 			};
 			// Detect pre-installation tampering: if either global is already
 			// set and was NOT installed by this plugin, refuse to proceed.

--- a/test/dom-abstraction.spec.ts
+++ b/test/dom-abstraction.spec.ts
@@ -442,6 +442,48 @@ describe("Runtime Installation with Dependency Injection", () => {
 		expect(script.getAttribute("crossorigin")).toBe("anonymous");
 	});
 
+	it("strips the configured base prefix when looking up integrity for DOM elements", () => {
+		// Map keys are '/'-rooted bundle file names WITHOUT the Vite base;
+		// element URLs observed at runtime include it under sub-path
+		// deployments. The lookup must strip the base before retrying.
+		const sriMap = { "/assets/main.js": "sha256-based" };
+
+		const mockElement = { prototype: { setAttribute: () => {} } };
+		const mockNode = {
+			prototype: { appendChild: () => {}, insertBefore: () => {} },
+		};
+		const originalElement = (globalThis as any).Element;
+		const originalNode = (globalThis as any).Node;
+
+		try {
+			(globalThis as any).Element = mockElement;
+			(globalThis as any).Node = mockNode;
+
+			installSriRuntimeWithDeps(
+				sriMap,
+				{ crossorigin: "anonymous", base: "/app/" },
+				dependencies
+			);
+
+			// The callback handed to wrapSetAttribute is the runtime's
+			// element processor; drive it directly with a script whose
+			// resolved URL includes the base prefix.
+			const processElement =
+				dependencies.mocks.nodeAdapter.wrapSetAttribute.mock
+					.calls[0][1];
+			const script = mockElements.createScript({
+				src: "/app/assets/main.js",
+			});
+			processElement(script);
+
+			expect(script.getAttribute("integrity")).toBe("sha256-based");
+			expect(script.getAttribute("crossorigin")).toBe("anonymous");
+		} finally {
+			(globalThis as any).Element = originalElement;
+			(globalThis as any).Node = originalNode;
+		}
+	});
+
 	it("handles errors gracefully", () => {
 		const sriMap = { "/test.js": "sha256-abc123" };
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -2158,6 +2158,35 @@ describe("vite-plugin-sri-gen", () => {
 			expect(entryCode).toContain("installSriRuntime");
 		});
 
+		it("passes the configured Vite base through to the injected runtime", async () => {
+			const plugin = sri({
+				algorithm: "sha256",
+				preloadDynamicChunks: false,
+				runtimePatchDynamicLinks: true,
+			}) as any;
+			plugin.configResolved?.({
+				base: "/app/",
+				build: { ssr: false },
+			} as any);
+
+			const bundle: Record<string, Chunk | Asset> = {
+				"index.html": { type: "asset", source: htmlDoc("") },
+				"assets/entry.js": makeEntryChunk({
+					code: "const p = import('./lazy.js');",
+					dynamicImports: ["src/lazy.ts"],
+				}),
+				"assets/lazy.js": makeDynChunk(
+					"assets/lazy.js",
+					"src/lazy.ts"
+				),
+			} as any;
+
+			await plugin.generateBundle.handler({}, bundle as any);
+
+			const entryCode = (bundle["assets/entry.js"] as Chunk).code;
+			expect(entryCode).toContain('base: "/app/"');
+		});
+
 		it("does not rewrite import() or enable enforcement when preload injection is enabled (default)", async () => {
 			const plugin = sri({
 				algorithm: "sha256",
@@ -2448,6 +2477,33 @@ describe("buildSriRuntimeCode (issue #30: self-contained injected runtime)", () 
 		expect(code).toContain('skipResources: ["analytics-*"]');
 		expect(code).toContain("enforceDynamicImports: false");
 		expect(code).toContain('{"/a.js":"sha384-x"}');
+	});
+
+	it("serializes the base option into the injected runtime arguments", () => {
+		const code = buildSriRuntimeCode(
+			installSriRuntime,
+			{ "/assets/lazy.js": "sha256-abc" },
+			{
+				crossorigin: "anonymous",
+				skipResources: [],
+				enforceDynamicImports: true,
+				base: "/app/",
+			}
+		);
+		expect(code).toContain('base: "/app/"');
+	});
+
+	it("defaults the serialized base to '/' when not provided", () => {
+		const code = buildSriRuntimeCode(
+			installSriRuntime,
+			{ "/a.js": "sha384-x" },
+			{
+				crossorigin: undefined,
+				skipResources: [],
+				enforceDynamicImports: false,
+			}
+		);
+		expect(code).toContain('base: "/"');
 	});
 
 	it("escapes `<` in serialized data so it cannot break out of the injected script", () => {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -2110,9 +2110,12 @@ describe("vite-plugin-sri-gen", () => {
 			const out = rewriteDynamicImports(input);
 
 			expect(out).toContain("import x from 'a';");
-			expect(out).toContain("__sriImport('./lazy.js')");
-			expect(out).toContain("__sriImport( './lazy2.js' )");
-			expect(out).toContain("import.meta.url");
+			// The importer's module URL must be threaded through so the
+			// runtime can resolve relative specifiers the way native
+			// import() does (issue #32).
+			expect(out).toContain("__sriImport(import.meta.url, './lazy.js')");
+			expect(out).toContain("__sriImport(import.meta.url,  './lazy2.js' )");
+			expect(out).toContain("console.log(import.meta.url);");
 			expect(out).toContain("obj.import('./should-not-touch.js')");
 			// String literals are an accepted false-positive surface; ensure it
 			// at least does not corrupt the file structure.
@@ -2149,7 +2152,7 @@ describe("vite-plugin-sri-gen", () => {
 			await plugin.generateBundle.handler({}, bundle as any);
 
 			const entryCode = (bundle["assets/entry.js"] as Chunk).code;
-			expect(entryCode).toContain("__sriImport('./lazy.js')");
+			expect(entryCode).toContain("__sriImport(import.meta.url, './lazy.js')");
 			expect(entryCode).not.toMatch(/[^.\w$]import\s*\(\s*['"]\.\/lazy\.js/);
 			expect(entryCode).toContain("enforceDynamicImports: true");
 			expect(entryCode).toContain("installSriRuntime");
@@ -2230,7 +2233,7 @@ describe("vite-plugin-sri-gen", () => {
 			await plugin.generateBundle.handler({}, bundle as any);
 
 			const outerCode = (bundle["assets/outer.js"] as Chunk).code;
-			expect(outerCode).toContain("__sriImport('./inner.js')");
+			expect(outerCode).toContain("__sriImport(import.meta.url, './inner.js')");
 			expect(outerCode).not.toMatch(/[^.\w$]import\s*\(\s*['"]\.\/inner\.js/);
 		});
 
@@ -2293,8 +2296,8 @@ describe("vite-plugin-sri-gen", () => {
 
 			const aCode = (bundle["assets/entry-a.js"] as Chunk).code;
 			const bCode = (bundle["assets/entry-b.js"] as Chunk).code;
-			expect(aCode).toContain("__sriImport('./shared.js')");
-			expect(bCode).toContain("__sriImport('./shared.js')");
+			expect(aCode).toContain("__sriImport(import.meta.url, './shared.js')");
+			expect(bCode).toContain("__sriImport(import.meta.url, './shared.js')");
 			expect(aCode).toContain("installSriRuntime");
 			expect(bCode).toContain("installSriRuntime");
 		});

--- a/test/internal.spec.ts
+++ b/test/internal.spec.ts
@@ -5584,6 +5584,39 @@ describe("Coverage Gap Closures", () => {
 			expect(fetched).toEqual(["https://app.test/app/assets/lazy.js"]);
 		});
 
+		it("__sriImport matches integrity by pathname when the specifier carries a query string", async () => {
+			// Lookup keys never include query strings; the URL pathname does
+			// the matching while fetch/import keep the full URL intact.
+			const content = "export const versioned = 1;";
+			const integrity = await expectedHash(content, "SHA-256");
+
+			const fetched: string[] = [];
+			(globalThis as any).fetch = vi.fn(async (u: any) => {
+				fetched.push(String(u));
+				return {
+					ok: true,
+					status: 200,
+					arrayBuffer: async () =>
+						new TextEncoder().encode(content).buffer,
+				};
+			});
+
+			installSriRuntime(
+				{ "/assets/lazy.js": integrity },
+				{ enforceDynamicImports: true }
+			);
+			(globalThis as any).__sriNativeImport = () =>
+				Promise.resolve({ ok: true });
+
+			await expect(
+				(globalThis as any).__sriImport(
+					"https://app.test/assets/entry.js",
+					"./lazy.js?v=2"
+				)
+			).resolves.toEqual({ ok: true });
+			expect(fetched).toEqual(["https://app.test/assets/lazy.js?v=2"]);
+		});
+
 		it("__sriImport reports the resolved URL when no integrity is registered", async () => {
 			installSriRuntime({}, { enforceDynamicImports: true });
 			await expect(

--- a/test/internal.spec.ts
+++ b/test/internal.spec.ts
@@ -5222,6 +5222,7 @@ describe("Coverage Gap Closures", () => {
 			installSriRuntime({}, { enforceDynamicImports: true });
 			await expect(
 				(globalThis as any).__sriImport(
+					undefined,
 					"https://app.test/assets/unknown.js"
 				)
 			).rejects.toThrow(/no integrity registered/i);
@@ -5250,6 +5251,7 @@ describe("Coverage Gap Closures", () => {
 			};
 
 			const result = await (globalThis as any).__sriImport(
+				undefined,
 				"https://app.test/assets/lazy.js"
 			);
 			expect(result).toEqual({ ok: true });
@@ -5276,6 +5278,7 @@ describe("Coverage Gap Closures", () => {
 
 			await expect(
 				(globalThis as any).__sriImport(
+					undefined,
 					"https://app.test/assets/lazy.js"
 				)
 			).rejects.toThrow(/integrity verification failed/i);
@@ -5297,6 +5300,7 @@ describe("Coverage Gap Closures", () => {
 
 			await expect(
 				(globalThis as any).__sriImport(
+					undefined,
 					"https://app.test/assets/lazy.js"
 				)
 			).rejects.toThrow(/HTTP 503/);
@@ -5309,6 +5313,7 @@ describe("Coverage Gap Closures", () => {
 			);
 			await expect(
 				(globalThis as any).__sriImport(
+					undefined,
 					"https://app.test/assets/lazy.js"
 				)
 			).rejects.toThrow(/unsupported integrity algorithm/i);
@@ -5336,6 +5341,7 @@ describe("Coverage Gap Closures", () => {
 				Promise.resolve({});
 
 			await (globalThis as any).__sriImport(
+				undefined,
 				"https://app.test/assets/lazy.js"
 			);
 
@@ -5367,6 +5373,7 @@ describe("Coverage Gap Closures", () => {
 				Promise.resolve({});
 
 			await (globalThis as any).__sriImport(
+				undefined,
 				"https://app.test/assets/lazy.js"
 			);
 
@@ -5395,6 +5402,7 @@ describe("Coverage Gap Closures", () => {
 				Promise.resolve({});
 
 			await (globalThis as any).__sriImport(
+				undefined,
 				"https://app.test/assets/lazy.js"
 			);
 
@@ -5468,6 +5476,7 @@ describe("Coverage Gap Closures", () => {
 				vi.stubGlobal("crypto", { subtle: undefined });
 				await expect(
 					(globalThis as any).__sriImport(
+						undefined,
 						"https://app.test/assets/lazy.js"
 					)
 				).rejects.toThrow(
@@ -5476,6 +5485,115 @@ describe("Coverage Gap Closures", () => {
 			} finally {
 				vi.stubGlobal("crypto", origCrypto);
 			}
+		});
+
+		it("__sriImport resolves module-relative specifiers against the importing module's URL", async () => {
+			// A chunk at /assets/js/parent.js imports './asset.js'. Native
+			// import() resolves that against the importing module's URL, so
+			// the runtime must do the same — NOT against location.href.
+			const content = "export const nested = true;";
+			const integrity = await expectedHash(content, "SHA-256");
+
+			const fetched: string[] = [];
+			(globalThis as any).fetch = vi.fn(async (u: any) => {
+				fetched.push(String(u));
+				return {
+					ok: true,
+					status: 200,
+					arrayBuffer: async () =>
+						new TextEncoder().encode(content).buffer,
+				};
+			});
+
+			installSriRuntime(
+				{ "/assets/js/asset.js": integrity },
+				{ enforceDynamicImports: true }
+			);
+
+			const nativeCalls: string[] = [];
+			(globalThis as any).__sriNativeImport = (u: string) => {
+				nativeCalls.push(u);
+				return Promise.resolve({ ok: true });
+			};
+
+			const result = await (globalThis as any).__sriImport(
+				"https://app.test/assets/js/parent.js",
+				"./asset.js"
+			);
+			expect(result).toEqual({ ok: true });
+			// Fetch and native import must both use the SAME resolved URL so
+			// the verified bytes are the executed bytes.
+			expect(fetched).toEqual(["https://app.test/assets/js/asset.js"]);
+			expect(nativeCalls).toEqual([
+				"https://app.test/assets/js/asset.js",
+			]);
+		});
+
+		it("__sriImport falls back to location.href when no importer URL is provided", async () => {
+			const content = "export const v = 2;";
+			const integrity = await expectedHash(content, "SHA-256");
+			(globalThis as any).fetch = vi.fn(async () => ({
+				ok: true,
+				status: 200,
+				arrayBuffer: async () =>
+					new TextEncoder().encode(content).buffer,
+			}));
+
+			installSriRuntime(
+				{ "/assets/lazy.js": integrity },
+				{ enforceDynamicImports: true }
+			);
+			(globalThis as any).__sriNativeImport = () =>
+				Promise.resolve({ ok: true });
+
+			await expect(
+				(globalThis as any).__sriImport(undefined, "/assets/lazy.js")
+			).resolves.toEqual({ ok: true });
+		});
+
+		it("__sriImport strips the configured base prefix when looking up integrity", async () => {
+			// Map keys are '/'-rooted bundle file names without the Vite base;
+			// resolved URLs under a sub-path deployment include it.
+			const content = "export const based = 1;";
+			const integrity = await expectedHash(content, "SHA-256");
+
+			const fetched: string[] = [];
+			(globalThis as any).fetch = vi.fn(async (u: any) => {
+				fetched.push(String(u));
+				return {
+					ok: true,
+					status: 200,
+					arrayBuffer: async () =>
+						new TextEncoder().encode(content).buffer,
+				};
+			});
+
+			installSriRuntime(
+				{ "/assets/lazy.js": integrity },
+				{ enforceDynamicImports: true, base: "/app/" }
+			);
+			(globalThis as any).__sriNativeImport = () =>
+				Promise.resolve({ ok: true });
+
+			await expect(
+				(globalThis as any).__sriImport(
+					"https://app.test/app/assets/entry.js",
+					"./lazy.js"
+				)
+			).resolves.toEqual({ ok: true });
+			expect(fetched).toEqual(["https://app.test/app/assets/lazy.js"]);
+		});
+
+		it("__sriImport reports the resolved URL when no integrity is registered", async () => {
+			installSriRuntime({}, { enforceDynamicImports: true });
+			await expect(
+				(globalThis as any).__sriImport(
+					"https://app.test/assets/js/parent.js",
+					"./asset.js"
+				)
+			).rejects.toThrow(
+				/no integrity registered for \.\/asset\.js \(resolved to https:\/\/app\.test\/assets\/js\/asset\.js\)/i
+			);
 		});
 	});
 });


### PR DESCRIPTION
Fixes #32

## Root cause

The `import(` → `__sriImport(` rewrite discarded the importing module's URL context. Native `import("./asset.js")` resolves the specifier against the **importing module's URL** (`import.meta.url`), but the injected runtime resolved it against `location.href`. Rollup emits inter-chunk dynamic imports as module-relative specifiers, so a chunk at `/assets/js/parent.js` importing `./asset.js` was looked up as `/asset.js` while its integrity was registered under `/assets/js/asset.js` — every nested dynamic import failed with *"no integrity registered"*.

This also explains the manual-key experiment in the issue: lookups are by absolutized URL pathname, so a `./`-prefixed map key can never match.

Two latent bugs shared the same root cause:

- `fetch()` resolved the raw specifier against the **document** URL while `__sriNativeImport` resolved it against the **entry chunk's** URL (where the runtime lives) — the verified bytes and the executed module could be different files.
- Under a sub-path `base` (e.g. `/app/`), resolved pathnames include the base prefix but the integrity map keys never do, so lookups failed.

## Fix

- The rewrite now emits `__sriImport(import.meta.url, <specifier>)`, threading the importer's URL through to the runtime.
- `sriImport` resolves the specifier **once** against the importer's URL (falling back to `location.href`), and that single resolved URL drives the integrity lookup, the verification fetch, and the native import — verified bytes are always the executed bytes.
- Integrity lookups strip the configured Vite `base` prefix, fixing sub-path deployments for both dynamic imports and the runtime DOM-patching path.
- The "no integrity registered" error now includes the resolved URL for diagnosability.

## Verification

- 4 new tests written first (TDD) reproducing the exact failure: module-relative resolution, `location.href` fallback, base-prefix stripping, and resolved-URL error reporting. All failed pre-fix for the reported reason; all pass post-fix. Full suite: 391/391.
- End-to-end against a real Vite build with nested `assets/js/` chunk output (the issue's layout): the lazy chunk loads through `__sriImport` in a live browser, and a tampered chunk is still rejected (fail-closed behavior intact).

## Note on the static re-export observation

The issue also mentions facade chunks that import-and-immediately-export via **static** imports. Static inter-chunk imports cannot be intercepted at the JS level — those are covered by `modulepreload` integrity when `preloadDynamicChunks` is enabled. Not a regression from this change.