### PR TITLE
feat: import map integrity mode — native SRI for module chunks

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,9 +158,29 @@ sri({
 
 ### Lazy-loaded chunks and dynamic tags
 
-- If `preloadDynamicChunks` is enabled (default), the plugin scans Rollup output for dynamically imported chunks and injects `<link rel="modulepreload" integrity=...>` for them into emitted HTML, honoring Vite `base` and `crossorigin`. Browser-native SRI then validates each lazy chunk via its preload entry.
-- If `preloadDynamicChunks` is disabled (preserving on-demand network behavior for lazy chunks), the plugin instead enforces SRI at the JavaScript layer: every dynamic `import(...)` call site in the bundle is rewritten to a runtime helper that fetches the chunk, verifies its hash against the build-time integrity using `crypto.subtle`, and only then performs the native import. A mismatch throws and aborts module loading. This requires `runtimePatchDynamicLinks` (default on), a [secure context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts) for `crypto.subtle` (HTTPS or localhost), and matching CORS configuration on the server hosting the chunks. The helper performs a separate verification fetch in addition to the browser's own module fetch — keep `Cache-Control: immutable` (or equivalent) on hashed chunk filenames to avoid a true second network round-trip. Source maps for chunks whose `import()` call sites are rewritten are dropped (the rewrite shifts byte offsets); the original source maps are preserved for any chunk that does not contain a dynamic import.
+- Whenever the build emits HTML (and `base` is root-relative or an absolute URL), the plugin injects a `<script type="importmap">` into each HTML file with an [`integrity`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap#integrity_metadata_map) object covering every emitted JS module. Browsers with import map integrity support (Chrome 127+, Firefox 138+, Safari 18.4+) enforce SRI natively on **both static and dynamic** module imports — including statically re-exported facade chunks that `modulepreload` discovery does not reach. Older browsers ignore the `integrity` key (progressive enhancement, the same model as SRI attributes generally). If your HTML already declares an import map, the integrity entries are merged into it; your own entries win on conflict. See [Import Map Integrity](#import-map-integrity).
+- If `preloadDynamicChunks` is enabled (default), the plugin additionally scans Rollup output for dynamically imported chunks and injects `<link rel="modulepreload" integrity=...>` for them into emitted HTML, honoring Vite `base` and `crossorigin`. Browser-native SRI then validates each lazy chunk via its preload entry (and preloading changes network timing: lazy chunks are fetched eagerly).
+- If `preloadDynamicChunks` is disabled and the import map **cannot** be emitted (no HTML in the bundle — e.g. backend-owned HTML consuming `manifest.json` — or a relative `base` like `'./'`), the plugin falls back to enforcing SRI at the JavaScript layer: every dynamic `import(...)` call site in the bundle is rewritten to a runtime helper that fetches the chunk, verifies its hash against the build-time integrity using `crypto.subtle`, and only then performs the native import. A mismatch throws and aborts module loading. This fallback requires `runtimePatchDynamicLinks` (default on), a [secure context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts) for `crypto.subtle` (HTTPS or localhost), and matching CORS configuration on the server hosting the chunks. The helper performs a separate verification fetch in addition to the browser's own module fetch — keep `Cache-Control: immutable` (or equivalent) on hashed chunk filenames to avoid a true second network round-trip. Source maps for chunks whose `import()` call sites are rewritten are dropped (the rewrite shifts byte offsets). Builds covered by the import map have none of these constraints.
 - If `runtimePatchDynamicLinks` is enabled (default), a tiny runtime is prepended to entry chunks. It sets `integrity` (and `crossorigin` if configured) on dynamically created `<script>` and `<link>` elements for eligible resources (scripts, stylesheets, modulepreload, or preload as=script/style/font) before the network request happens. This is bundled code (not inline) and is CSP-safe.
+
+## Import Map Integrity
+
+When the build emits HTML, SRI for module chunks is declared in an injected import map:
+
+```html
+<script type="importmap">
+{"integrity":{"/assets/index-B3sb0LQp.js":"sha384-…","/assets/chunk-Cab12xJ4.js":"sha384-…"}}
+</script>
+```
+
+Supporting browsers (Chrome 127+, Firefox 138+, Safari 18.4+) apply the integrity metadata to every matching module fetch — static imports, dynamic `import()`, and module preloads alike — and refuse to execute a module whose bytes do not match.
+
+Notes:
+
+- **CSP:** the import map is necessarily an inline script (the HTML spec forbids `src` on import maps). Strict `script-src` policies without `'unsafe-inline'` must allow it via a nonce (server-side templating) or a hash — note the hash changes every build, since the map contains the chunk hashes.
+- **Workers:** import maps do not apply inside Web Workers or Service Workers; module chunks loaded there are not covered (the JS-runtime fallback does not cover them either).
+- **Relative `base`:** with `base: './'` (or `''`/`'../…'`), import map keys cannot be expressed portably (keys resolve against each document's URL), so injection is skipped and the JS-runtime fallback remains active for `preloadDynamicChunks: false` builds.
+- **Older browsers:** Chrome < 127, Firefox < 138, and Safari < 18.4 parse the map but ignore `integrity` — module loads proceed unverified there, exactly as HTML `integrity` attributes behave on browsers without SRI support.
 
 ## Runtime Patching
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@
 - [Configuration](#configuration)
 - [Skipping Resources](#skipping-resources)
 - [Lazy-loaded Chunks and Dynamic Tags](#lazy-loaded-chunks-and-dynamic-tags)
+- [Import Map Integrity](#import-map-integrity)
 - [Runtime Patching](#runtime-patching)
 - [Vite Manifest Integration](#vite-manifest-integration)
 - [Compatibility](#compatibility)
@@ -107,7 +108,7 @@ type SriPluginOptions = {
   crossorigin?: "anonymous" | "use-credentials"; // default: undefined
   fetchCache?: boolean; // default: true (in-memory cache + in-flight dedupe for remote assets)
   fetchTimeoutMs?: number; // default: 5000 (5 seconds). Abort remote fetches after N ms, 0 to disable timeout
-  preloadDynamicChunks?: boolean; // default: true. Inject rel="modulepreload" with integrity for discovered lazy chunks
+  preloadDynamicChunks?: boolean; // default: true. Inject rel="modulepreload" with integrity for discovered lazy chunks. When false, dynamic imports are covered by the injected import map where possible (HTML-only bundle, root-relative/absolute base); JS-level import() rewriting is the fallback for no-HTML, mixed HTML+manifest, or relative-base builds.
   runtimePatchDynamicLinks?: boolean; // default: true. Inject a tiny runtime that adds integrity to dynamically created <script>/<link>
   skipResources?: string[]; // default: []. Skip SRI for resources matching these patterns (by id or src/href)
   verboseLogging?: boolean; // default: false. Show all info-level build logs. When false, only warnings, errors, and a completion summary are shown.
@@ -158,9 +159,9 @@ sri({
 
 ### Lazy-loaded chunks and dynamic tags
 
-- Whenever the build emits HTML (and `base` is root-relative or an absolute URL), the plugin injects a `<script type="importmap">` into each HTML file with an [`integrity`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap#integrity_metadata_map) object covering every emitted JS module. Browsers with import map integrity support (Chrome 127+, Firefox 138+, Safari 18.4+) enforce SRI natively on **both static and dynamic** module imports — including statically re-exported facade chunks that `modulepreload` discovery does not reach. Older browsers ignore the `integrity` key (progressive enhancement, the same model as SRI attributes generally). If your HTML already declares an import map, the integrity entries are merged into it; your own entries win on conflict. See [Import Map Integrity](#import-map-integrity).
+- Whenever the build emits HTML (and `base` is root-relative or an absolute URL), the plugin injects a `<script type="importmap">` into each HTML file with an [`integrity`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap#integrity_metadata_map) object covering every emitted JS module. Browsers with import map integrity support (Chrome 127+, Firefox 138+, Safari 18+) enforce SRI natively on **both static and dynamic** module imports — including statically imported chunks (such as facade re-exports) that `modulepreload` discovery never scans. Older browsers ignore the `integrity` key (progressive enhancement, the same model as SRI attributes generally). If your HTML already declares an import map, the integrity entries are merged into it; your own entries win on conflict. See [Import Map Integrity](#import-map-integrity).
 - If `preloadDynamicChunks` is enabled (default), the plugin additionally scans Rollup output for dynamically imported chunks and injects `<link rel="modulepreload" integrity=...>` for them into emitted HTML, honoring Vite `base` and `crossorigin`. Browser-native SRI then validates each lazy chunk via its preload entry (and preloading changes network timing: lazy chunks are fetched eagerly).
-- If `preloadDynamicChunks` is disabled and the import map **cannot** be emitted (no HTML in the bundle — e.g. backend-owned HTML consuming `manifest.json` — or a relative `base` like `'./'`), the plugin falls back to enforcing SRI at the JavaScript layer: every dynamic `import(...)` call site in the bundle is rewritten to a runtime helper that fetches the chunk, verifies its hash against the build-time integrity using `crypto.subtle`, and only then performs the native import. A mismatch throws and aborts module loading. This fallback requires `runtimePatchDynamicLinks` (default on), a [secure context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts) for `crypto.subtle` (HTTPS or localhost), and matching CORS configuration on the server hosting the chunks. The helper performs a separate verification fetch in addition to the browser's own module fetch — keep `Cache-Control: immutable` (or equivalent) on hashed chunk filenames to avoid a true second network round-trip. Source maps for chunks whose `import()` call sites are rewritten are dropped (the rewrite shifts byte offsets). Builds covered by the import map have none of these constraints.
+- If `preloadDynamicChunks` is disabled and the import map cannot cover every consumer of the bundle (no HTML in the bundle — e.g. backend-owned HTML consuming `manifest.json` — a manifest emitted **alongside** HTML, or a relative `base` like `'./'`), the plugin falls back to enforcing SRI at the JavaScript layer: every dynamic `import(...)` call site in the bundle is rewritten to a runtime helper that fetches the chunk, verifies its hash against the build-time integrity using `crypto.subtle`, and only then performs the native import. A mismatch throws and aborts module loading. This fallback requires `runtimePatchDynamicLinks` (default on), a [secure context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts) for `crypto.subtle` (HTTPS or localhost), and matching CORS configuration on the server hosting the chunks. The helper performs a separate verification fetch in addition to the browser's own module fetch — keep `Cache-Control: immutable` (or equivalent) on hashed chunk filenames to avoid a true second network round-trip. Source maps for chunks whose `import()` call sites are rewritten are dropped (the rewrite shifts byte offsets). Builds covered by the import map have none of these constraints.
 - If `runtimePatchDynamicLinks` is enabled (default), a tiny runtime is prepended to entry chunks. It sets `integrity` (and `crossorigin` if configured) on dynamically created `<script>` and `<link>` elements for eligible resources (scripts, stylesheets, modulepreload, or preload as=script/style/font) before the network request happens. This is bundled code (not inline) and is CSP-safe.
 
 ## Import Map Integrity
@@ -173,14 +174,15 @@ When the build emits HTML, SRI for module chunks is declared in an injected impo
 </script>
 ```
 
-Supporting browsers (Chrome 127+, Firefox 138+, Safari 18.4+) apply the integrity metadata to every matching module fetch — static imports, dynamic `import()`, and module preloads alike — and refuse to execute a module whose bytes do not match.
+Supporting browsers (Chrome 127+, Firefox 138+, Safari 18+) apply the integrity metadata to every matching module fetch — static imports, dynamic `import()`, and module preloads alike — and refuse to execute a module whose bytes do not match.
 
 Notes:
 
 - **CSP:** the import map is necessarily an inline script (the HTML spec forbids `src` on import maps). Strict `script-src` policies without `'unsafe-inline'` must allow it via a nonce (server-side templating) or a hash — note the hash changes every build, since the map contains the chunk hashes.
 - **Workers:** import maps do not apply inside Web Workers or Service Workers; module chunks loaded there are not covered (the JS-runtime fallback does not cover them either).
 - **Relative `base`:** with `base: './'` (or `''`/`'../…'`), import map keys cannot be expressed portably (keys resolve against each document's URL), so injection is skipped and the JS-runtime fallback remains active for `preloadDynamicChunks: false` builds.
-- **Older browsers:** Chrome < 127, Firefox < 138, and Safari < 18.4 parse the map but ignore `integrity` — module loads proceed unverified there, exactly as HTML `integrity` attributes behave on browsers without SRI support.
+- **Older browsers:** Chrome < 127, Firefox < 138, and Safari < 18 parse the map but ignore `integrity` — module loads proceed unverified there, exactly as HTML `integrity` attributes behave on browsers without SRI support. Note that with `runtimePatchDynamicLinks: false` there is no JS-runtime fallback of any kind, so on those older browsers dynamic imports are entirely unverified regardless of the import map.
+- **Resources excluded via `skipResources`** are also excluded from the import map, so the opt-out applies to native module-fetch enforcement too.
 
 ## Runtime Patching
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import {
 	HtmlProcessor,
 	installSriRuntime,
 	IntegrityProcessor,
+	isImportMapCapableBase,
 	ManifestProcessor,
 	validateGenerateBundleInputs,
 } from "./internal";
@@ -268,12 +269,18 @@ export default function sri(options: SriPluginOptions = {}): PluginOption {
 						// any hashing so the served bytes match the hashed bytes.
 						// Activation condition: the user has disabled the
 						// build-time modulepreload injection (preloadDynamicChunks
-						// is false), which means browser-native SRI on
-						// modulepreload cannot be relied upon to protect lazy
-						// chunks. In that case we substitute the global SRI
-						// verifier injected by the runtime so every dynamic
-						// import goes through a strict, in-JS integrity check.
-						const enforceDynamicImports = !preloadDynamicChunks;
+						// is false) AND the import map cannot be emitted. JS-level
+						// enforcement is the fallback for builds where the import
+						// map is impossible: no HTML in the bundle (backend-owned
+						// HTML / manifest consumers) or a relative base (no valid
+						// import map keys). Wherever the import map IS emitted it
+						// subsumes this path — the browser enforces SRI natively
+						// on module fetches (single fetch, no rewrite, source
+						// maps kept).
+						const importMapCapable =
+							hasHtmlFiles && isImportMapCapableBase(base);
+						const enforceDynamicImports =
+							!preloadDynamicChunks && !importMapCapable;
 						if (enforceDynamicImports) {
 							// ORDERING INVARIANT: this rewrite MUST run before
 							// any hashing AND before the runtime is injected

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import type { BundleLogger } from "./internal";
 import {
 	createLogger,
 	DynamicImportAnalyzer,
+	escapeForScript,
 	handleGenerateBundleError,
 	HtmlProcessor,
 	installSriRuntime,
@@ -110,17 +111,11 @@ export function buildSriRuntimeCode(
 		base?: string;
 	}
 ): string {
-	// `JSON.stringify` does not escape `<` or the U+2028/U+2029 line separators.
-	// The serialized data is embedded as a JS string literal inside code that is
-	// prepended to a chunk, so escape those characters to keep the injected
-	// statement well-formed (and safe if a chunk is ever inlined into HTML).
-	// This only changes the source representation; the parsed runtime values are
-	// identical.
-	const escapeForScript = (json: string): string =>
-		json
-			.replace(/</g, "\\u003c")
-			.replace(/\u2028/g, "\\u2028")
-			.replace(/\u2029/g, "\\u2029");
+	// The serialized data is embedded as a JS string literal inside code that
+	// is prepended to a chunk; escapeForScript (shared with the import map
+	// injection) keeps the injected statement well-formed and safe if a chunk
+	// is ever inlined into HTML. This only changes the source representation;
+	// the parsed runtime values are identical.
 	const serializedMap = escapeForScript(JSON.stringify(sriByPathname));
 	const cors = opts.crossorigin ? JSON.stringify(opts.crossorigin) : "false";
 	const serializedSkipPatterns = escapeForScript(
@@ -251,6 +246,14 @@ export default function sri(options: SriPluginOptions = {}): PluginOption {
 					if (!hasHtmlFiles && !hasManifestFiles) {
 						return;
 					}
+					// Logged once per build (not per HTML file): with a
+					// relative base, import map integrity keys cannot be
+					// expressed portably, so HTML processing skips injection.
+					if (hasHtmlFiles && !isImportMapCapableBase(base)) {
+						logger.info(
+							`Import map SRI skipped: relative base "${base}" cannot produce valid import map keys`
+						);
+					}
 
 					const integrityProcessor = new IntegrityProcessor(
 						algorithm,
@@ -269,16 +272,22 @@ export default function sri(options: SriPluginOptions = {}): PluginOption {
 						// any hashing so the served bytes match the hashed bytes.
 						// Activation condition: the user has disabled the
 						// build-time modulepreload injection (preloadDynamicChunks
-						// is false) AND the import map cannot be emitted. JS-level
-						// enforcement is the fallback for builds where the import
-						// map is impossible: no HTML in the bundle (backend-owned
-						// HTML / manifest consumers) or a relative base (no valid
-						// import map keys). Wherever the import map IS emitted it
-						// subsumes this path — the browser enforces SRI natively
-						// on module fetches (single fetch, no rewrite, source
-						// maps kept).
+						// is false) AND the import map cannot cover every consumer
+						// of this bundle. JS-level enforcement is the fallback
+						// for builds where the import map is insufficient: no
+						// HTML in the bundle (backend-owned HTML / manifest
+						// consumers), a manifest emitted ALONGSIDE HTML (the
+						// manifest consumer's server-rendered pages have no
+						// import map, so suppressing the rewrite would silently
+						// drop their enforcement), or a relative base (no valid
+						// import map keys). Wherever the import map covers all
+						// consumers it subsumes this path — the browser enforces
+						// SRI natively on module fetches (single fetch, no
+						// rewrite, source maps kept).
 						const importMapCapable =
-							hasHtmlFiles && isImportMapCapableBase(base);
+							hasHtmlFiles &&
+							!hasManifestFiles &&
+							isImportMapCapableBase(base);
 						const enforceDynamicImports =
 							!preloadDynamicChunks && !importMapCapable;
 						if (enforceDynamicImports) {

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -156,6 +156,39 @@ export function joinBaseHref(base: string, chunkFile: string): string {
 }
 
 /**
+ * Whether the resolved Vite `base` can produce valid import map `integrity`
+ * keys. Import map keys must be URL-like — root-relative (`/...`),
+ * `./`/`../`-relative, or absolute URLs. The plugin only emits root-relative
+ * or absolute keys: a relative base (`./`, `../x/`, "") would require
+ * document-relative keys, which break for HTML pages in subdirectories
+ * (keys resolve against the DOCUMENT URL, not the deploy root).
+ */
+export function isImportMapCapableBase(base: string): boolean {
+	return base.startsWith("/") || isHttpUrl(base);
+}
+
+/**
+ * Builds the import map `integrity` object: emitted JS/MJS module URL → SRI
+ * metadata. Keys are joined with the configured Vite `base` exactly like
+ * injected modulepreload hrefs (see joinBaseHref), so they match the URLs the
+ * browser actually requests. Returns null when `base` is relative (no valid
+ * keys can be produced — see isImportMapCapableBase).
+ */
+export function buildImportIntegrityObject(
+	sriByPathname: Record<string, string>,
+	base: string
+): Record<string, string> | null {
+	if (!isImportMapCapableBase(base)) return null;
+	const result: Record<string, string> = {};
+	for (const [pathname, integrity] of Object.entries(sriByPathname)) {
+		if (!/\.m?js$/i.test(pathname)) continue;
+		const fileName = pathname.startsWith("/") ? pathname.slice(1) : pathname;
+		result[joinBaseHref(base, fileName)] = integrity;
+	}
+	return result;
+}
+
+/**
  * Extracts the pathname from a resource URL, handling absolute CDN URLs.
  * When the resource URL is an absolute HTTP/HTTPS URL, extracts just the pathname
  * portion for hash lookup. For relative or root-relative URLs, normalizes them

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -10,6 +10,7 @@ import { defaultDependencies } from "./dom-abstraction";
 type Document = DefaultTreeAdapterTypes.Document;
 type Element = DefaultTreeAdapterTypes.Element;
 type ChildNode = DefaultTreeAdapterTypes.ChildNode;
+type TextNode = DefaultTreeAdapterTypes.TextNode;
 
 // =======================================================
 // #region INTERFACES AND TYPES
@@ -100,6 +101,19 @@ export interface HtmlProcessorConfig {
  */
 export function isHttpUrl(url: unknown): boolean {
 	return typeof url === "string" && /^(https?:)?\/\//i.test(url);
+}
+
+/**
+ * Escapes characters that could terminate the surrounding <script> context
+ * or break JS parsing when JSON is inlined into HTML. The replacements are
+ * valid JSON escapes, so JSON.parse on the result is unaffected. Mirrors
+ * `escapeForScript` in index.ts (kept local to avoid a module cycle).
+ */
+function escapeForScriptInternal(json: string): string {
+	return json
+		.replace(/</g, "\\u003c")
+		.replace(/\u2028/g, "\\u2028")
+		.replace(/\u2029/g, "\\u2029");
 }
 
 /**
@@ -1594,10 +1608,22 @@ export class HtmlProcessor {
 		}
 
 		// ========================================================================
+		// IMPORT MAP INTEGRITY INJECTION
+		// ========================================================================
+
+		// Step 3: Inject import map integrity (runs after preload injection so
+		// the unshift places the map BEFORE the modulepreload links).
+		processedHtml = this.injectImportMap(
+			processedHtml,
+			sriByPathname,
+			fileName
+		);
+
+		// ========================================================================
 		// BUNDLE UPDATE
 		// ========================================================================
 
-		// Step 3: Update asset source with processed HTML
+		// Step 4: Update asset source with processed HTML
 		asset.source = processedHtml;
 	}
 
@@ -1833,6 +1859,130 @@ export class HtmlProcessor {
 		head.childNodes.unshift(linkElement);
 
 		return true;
+	}
+
+	/**
+	 * Injects (or merges into) a `<script type="importmap">` carrying an
+	 * `integrity` object for every emitted JS module chunk. Browsers
+	 * supporting import map integrity (Chrome 127+, Firefox 138+,
+	 * Safari 18.4+) then enforce SRI natively on static AND dynamic module
+	 * imports — single fetch, no TOCTOU. Older browsers ignore the
+	 * `integrity` key (progressive enhancement, same model as SRI attributes
+	 * generally).
+	 *
+	 * Must run AFTER addDynamicChunkPreloads: both prepend via
+	 * head.childNodes.unshift, so running last places the import map FIRST —
+	 * the spec requires it before any module script or modulepreload link.
+	 *
+	 * No-ops (returning the input unchanged) when: base is relative (keys
+	 * would be bare specifiers), no JS chunks exist, <head> is missing, or an
+	 * existing import map contains unparseable JSON (warned).
+	 */
+	private injectImportMap(
+		htmlContent: string,
+		sriByPathname: Record<string, string>,
+		fileName: string
+	): string {
+		const integrityObject = buildImportIntegrityObject(
+			sriByPathname,
+			this.config.base
+		);
+		if (integrityObject === null) {
+			this.config.logger.info(
+				`Import map SRI skipped for ${fileName}: relative base "${this.config.base}" cannot produce valid import map keys`
+			);
+			return htmlContent;
+		}
+		if (Object.keys(integrityObject).length === 0) {
+			return htmlContent;
+		}
+
+		try {
+			const document = parse(htmlContent);
+			const head = findElements(
+				document,
+				(el) => el.nodeName?.toLowerCase() === "head"
+			)[0];
+			if (!head) {
+				this.config.logger.warn(
+					`No <head> element found in ${fileName}, skipping import map injection`
+				);
+				return htmlContent;
+			}
+
+			const existingMaps = findElements(head, (el) => {
+				if (el.nodeName?.toLowerCase() !== "script") return false;
+				return getAttrValue(el, "type")?.toLowerCase() === "importmap";
+			});
+
+			if (existingMaps.length > 0) {
+				// Browsers process multiple import maps inconsistently across
+				// versions — merge into the first map instead of adding
+				// another.
+				const existingEl = existingMaps[0];
+				const textChild = existingEl.childNodes.find(
+					(n): n is TextNode => n.nodeName === "#text"
+				);
+				let parsed: {
+					integrity?: Record<string, string>;
+					[k: string]: unknown;
+				};
+				try {
+					parsed = JSON.parse(textChild?.value ?? "{}");
+				} catch {
+					this.config.logger.warn(
+						`Existing <script type="importmap"> in ${fileName} contains invalid JSON; integrity entries not merged`
+					);
+					return htmlContent;
+				}
+				// User-authored integrity entries win on key collision.
+				parsed.integrity = {
+					...integrityObject,
+					...(parsed.integrity ?? {}),
+				};
+				const json = escapeForScriptInternal(JSON.stringify(parsed));
+				if (textChild) {
+					textChild.value = json;
+				} else {
+					existingEl.childNodes.push({
+						nodeName: "#text",
+						value: json,
+						parentNode: existingEl,
+					} as TextNode);
+				}
+			} else {
+				const json = escapeForScriptInternal(
+					JSON.stringify({ integrity: integrityObject })
+				);
+				const textNode = {
+					nodeName: "#text",
+					value: json,
+					parentNode: null,
+				} as unknown as TextNode;
+				const importMapEl: Element = {
+					nodeName: "script",
+					tagName: "script",
+					attrs: [{ name: "type", value: "importmap" }],
+					namespaceURI: "http://www.w3.org/1999/xhtml" as any,
+					childNodes: [textNode],
+					parentNode: head,
+					sourceCodeLocation: undefined,
+				};
+				(textNode as any).parentNode = importMapEl;
+				if (!head.childNodes) head.childNodes = [];
+				head.childNodes.unshift(importMapEl);
+			}
+
+			return serialize(document);
+		} catch (error) {
+			this.config.logger.error(
+				`Failed to inject import map into ${fileName}: ${
+					error instanceof Error ? error.message : String(error)
+				}`,
+				error instanceof Error ? error : undefined
+			);
+			return htmlContent;
+		}
 	}
 }
 

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -105,11 +105,13 @@ export function isHttpUrl(url: unknown): boolean {
 
 /**
  * Escapes characters that could terminate the surrounding <script> context
- * or break JS parsing when JSON is inlined into HTML. The replacements are
- * valid JSON escapes, so JSON.parse on the result is unaffected. Mirrors
- * `escapeForScript` in index.ts (kept local to avoid a module cycle).
+ * or break JS parsing when JSON is inlined into HTML or prepended to a
+ * chunk: `JSON.stringify` does not escape `<` or the U+2028/U+2029 line
+ * separators. The replacements are valid JSON escapes, so JSON.parse on the
+ * result is unaffected. Canonical copy \u2014 also used by buildSriRuntimeCode in
+ * index.ts.
  */
-function escapeForScriptInternal(json: string): string {
+export function escapeForScript(json: string): string {
 	return json
 		.replace(/</g, "\\u003c")
 		.replace(/\u2028/g, "\\u2028")
@@ -185,21 +187,43 @@ export function isImportMapCapableBase(base: string): boolean {
  * Builds the import map `integrity` object: emitted JS/MJS module URL → SRI
  * metadata. Keys are joined with the configured Vite `base` exactly like
  * injected modulepreload hrefs (see joinBaseHref), so they match the URLs the
- * browser actually requests. Returns null when `base` is relative (no valid
- * keys can be produced — see isImportMapCapableBase).
+ * browser actually requests. Files matching a `skipResources` pattern are
+ * excluded — the user opted those out of SRI enforcement entirely. Returns
+ * null when `base` is relative (no valid keys can be produced — see
+ * isImportMapCapableBase).
  */
 export function buildImportIntegrityObject(
 	sriByPathname: Record<string, string>,
-	base: string
+	base: string,
+	skipResources: string[] = []
 ): Record<string, string> | null {
 	if (!isImportMapCapableBase(base)) return null;
 	const result: Record<string, string> = {};
 	for (const [pathname, integrity] of Object.entries(sriByPathname)) {
-		if (!/\.m?js$/i.test(pathname)) continue;
+		// Match PROCESSABLE_EXTENSIONS semantics: allow a query suffix.
+		if (!/\.m?js(\?|$)/i.test(pathname)) continue;
 		const fileName = pathname.startsWith("/") ? pathname.slice(1) : pathname;
+		if (isSkippedResource(fileName, skipResources)) continue;
 		result[joinBaseHref(base, fileName)] = integrity;
 	}
 	return result;
+}
+
+/**
+ * Whether a bundle file matches any `skipResources` pattern. Patterns are
+ * tested against both the bare file name and its '/'-rooted form so patterns
+ * written either way match (same contract as manifest augmentation).
+ */
+export function isSkippedResource(
+	file: string,
+	skipResources: string[]
+): boolean {
+	if (!skipResources || skipResources.length === 0) return false;
+	for (const pattern of skipResources) {
+		if (matchesPattern(pattern, file)) return true;
+		if (matchesPattern(pattern, `/${file}`)) return true;
+	}
+	return false;
 }
 
 /**
@@ -1865,7 +1889,7 @@ export class HtmlProcessor {
 	 * Injects (or merges into) a `<script type="importmap">` carrying an
 	 * `integrity` object for every emitted JS module chunk. Browsers
 	 * supporting import map integrity (Chrome 127+, Firefox 138+,
-	 * Safari 18.4+) then enforce SRI natively on static AND dynamic module
+	 * Safari 18+) then enforce SRI natively on static AND dynamic module
 	 * imports — single fetch, no TOCTOU. Older browsers ignore the
 	 * `integrity` key (progressive enhancement, same model as SRI attributes
 	 * generally).
@@ -1874,9 +1898,10 @@ export class HtmlProcessor {
 	 * head.childNodes.unshift, so running last places the import map FIRST —
 	 * the spec requires it before any module script or modulepreload link.
 	 *
-	 * No-ops (returning the input unchanged) when: base is relative (keys
-	 * would be bare specifiers), no JS chunks exist, <head> is missing, or an
-	 * existing import map contains unparseable JSON (warned).
+	 * No-ops (returning the input unchanged) when: base is relative (the
+	 * resulting keys — bare or document-relative — cannot be used portably
+	 * across pages in subdirectories), no JS chunks exist, <head> is missing,
+	 * or an existing import map contains unparseable JSON (warned).
 	 */
 	private injectImportMap(
 		htmlContent: string,
@@ -1885,12 +1910,12 @@ export class HtmlProcessor {
 	): string {
 		const integrityObject = buildImportIntegrityObject(
 			sriByPathname,
-			this.config.base
+			this.config.base,
+			this.config.skipResources
 		);
+		// Relative base — no valid keys can be produced. The build-level log
+		// in generateBundle reports this once instead of once per HTML file.
 		if (integrityObject === null) {
-			this.config.logger.info(
-				`Import map SRI skipped for ${fileName}: relative base "${this.config.base}" cannot produce valid import map keys`
-			);
 			return htmlContent;
 		}
 		if (Object.keys(integrityObject).length === 0) {
@@ -1898,7 +1923,9 @@ export class HtmlProcessor {
 		}
 
 		try {
-			const document = parse(htmlContent);
+			const document = parse(htmlContent, {
+				sourceCodeLocationInfo: false,
+			});
 			const head = findElements(
 				document,
 				(el) => el.nodeName?.toLowerCase() === "head"
@@ -1908,6 +1935,23 @@ export class HtmlProcessor {
 					`No <head> element found in ${fileName}, skipping import map injection`
 				);
 				return htmlContent;
+			}
+
+			// An absolute-URL <base href> changes the document base URL the
+			// browser resolves import map keys against — root-relative keys
+			// like "/assets/x.js" would resolve against the <base> origin and
+			// may never match the URLs modules are actually served from.
+			// Build-time is the only place this is detectable; warn.
+			const baseEl = findElements(head, (el) => {
+				return (
+					el.nodeName?.toLowerCase() === "base" &&
+					isHttpUrl(getAttrValue(el, "href"))
+				);
+			});
+			if (baseEl.length > 0) {
+				this.config.logger.warn(
+					`${fileName} contains <base href="${getAttrValue(baseEl[0], "href")}">; import map integrity keys resolve against the document base URL and may not match the served module URLs`
+				);
 			}
 
 			const existingMaps = findElements(head, (el) => {
@@ -1935,12 +1979,26 @@ export class HtmlProcessor {
 					);
 					return htmlContent;
 				}
-				// User-authored integrity entries win on key collision.
+				// User-authored integrity entries win on key collision — but a
+				// divergence between a user-pinned hash and the build-computed
+				// hash is almost always a mistake (stale template, or a
+				// tampered build input), so surface it loudly.
+				const userIntegrity = parsed.integrity ?? {};
+				for (const [key, value] of Object.entries(userIntegrity)) {
+					if (
+						key in integrityObject &&
+						integrityObject[key] !== value
+					) {
+						this.config.logger.warn(
+							`Existing import map in ${fileName} pins integrity for ${key} (${String(value)}) that differs from the build-computed hash (${integrityObject[key]}); keeping the existing entry`
+						);
+					}
+				}
 				parsed.integrity = {
 					...integrityObject,
-					...(parsed.integrity ?? {}),
+					...userIntegrity,
 				};
-				const json = escapeForScriptInternal(JSON.stringify(parsed));
+				const json = escapeForScript(JSON.stringify(parsed));
 				if (textChild) {
 					textChild.value = json;
 				} else {
@@ -1951,7 +2009,7 @@ export class HtmlProcessor {
 					} as TextNode);
 				}
 			} else {
-				const json = escapeForScriptInternal(
+				const json = escapeForScript(
 					JSON.stringify({ integrity: integrityObject })
 				);
 				const textNode = {
@@ -2235,13 +2293,7 @@ export class ManifestProcessor {
 	}
 
 	private isSkipped(file: string, skipResources: string[]): boolean {
-		if (!skipResources || skipResources.length === 0) return false;
-		for (const pattern of skipResources) {
-			if (matchesPattern(pattern, file)) return true;
-			// Also allow patterns written with a leading slash to match
-			if (matchesPattern(pattern, `/${file}`)) return true;
-		}
-		return false;
+		return isSkippedResource(file, skipResources);
 	}
 }
 

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -609,6 +609,39 @@ function getAttrValue(element: Element, name: string): string | undefined {
 }
 
 /**
+ * Index in head.childNodes at which plugin-injected elements (import map,
+ * modulepreload links) should be inserted. The HTML spec wants the charset
+ * declaration within the first 1024 bytes of the document, and the injected
+ * content grows with chunk count — so insertion goes AFTER a
+ * charset-declaring <meta>, provided it appears before any script or link
+ * element (the import map must precede those). Falls back to the start of
+ * head otherwise.
+ */
+function headInjectionIndex(head: Element): number {
+	if (!head.childNodes) return 0;
+	for (let i = 0; i < head.childNodes.length; i++) {
+		const node = head.childNodes[i];
+		if (!("tagName" in node)) continue; // text/comment nodes
+		const el = node as Element;
+		const tag = el.tagName?.toLowerCase();
+		if (tag === "meta") {
+			const httpEquiv = getAttrValue(el, "http-equiv")?.toLowerCase();
+			if (
+				getAttrValue(el, "charset") !== undefined ||
+				httpEquiv === "content-type"
+			) {
+				return i + 1;
+			}
+			continue;
+		}
+		// A script or link already precedes any charset meta — injected
+		// content must come before it, so insert at the head start.
+		if (tag === "script" || tag === "link") return 0;
+	}
+	return 0;
+}
+
+/**
  * Helper function to set attribute value on parse5 element
  * @param element - parse5 Element
  * @param name - Attribute name
@@ -1876,11 +1909,13 @@ export class HtmlProcessor {
 			});
 		}
 
-		// Add the link element to the beginning of head
+		// Insert at the head start, but after a leading charset meta — the
+		// charset declaration must stay within the first 1024 bytes and the
+		// number of injected links grows with chunk count.
 		if (!head.childNodes) {
 			head.childNodes = [];
 		}
-		head.childNodes.unshift(linkElement);
+		head.childNodes.splice(headInjectionIndex(head), 0, linkElement);
 
 		return true;
 	}
@@ -1894,9 +1929,10 @@ export class HtmlProcessor {
 	 * `integrity` key (progressive enhancement, same model as SRI attributes
 	 * generally).
 	 *
-	 * Must run AFTER addDynamicChunkPreloads: both prepend via
-	 * head.childNodes.unshift, so running last places the import map FIRST —
-	 * the spec requires it before any module script or modulepreload link.
+	 * Must run AFTER addDynamicChunkPreloads: both insert at the same
+	 * computed head position (see headInjectionIndex), so running last places
+	 * the import map ahead of the injected links — the spec requires it
+	 * before any module script or modulepreload link.
 	 *
 	 * No-ops (returning the input unchanged) when: base is relative (the
 	 * resulting keys — bare or document-relative — cannot be used portably
@@ -2028,7 +2064,12 @@ export class HtmlProcessor {
 				};
 				(textNode as any).parentNode = importMapEl;
 				if (!head.childNodes) head.childNodes = [];
-				head.childNodes.unshift(importMapEl);
+				// Same insertion point the preload links use: after a leading
+				// charset meta (which must stay within the first 1024 bytes —
+				// the map grows with chunk count), otherwise the head start.
+				// Inserting at the same index AFTER the preload pass places
+				// the map before every injected link.
+				head.childNodes.splice(headInjectionIndex(head), 0, importMapEl);
 			}
 
 			return serialize(document);

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -2811,4 +2811,62 @@ describe("import map SRI", () => {
 			warnSpy.mockRestore();
 		}
 	});
+
+	it("keeps a leading meta charset before the injected import map", async () => {
+		const { plugin, bundle } = buildPluginBundle(
+			"/",
+			'<!doctype html><html><head><meta charset="utf-8"><title>t</title></head><body></body></html>'
+		);
+		await plugin.generateBundle.handler({}, bundle as any);
+		const html = String((bundle["index.html"] as Asset).source);
+		const charsetIdx = html.indexOf("<meta charset");
+		const mapIdx = html.indexOf('<script type="importmap">');
+		expect(charsetIdx).toBeGreaterThan(-1);
+		expect(mapIdx).toBeGreaterThan(-1);
+		// The charset declaration must stay within the first 1024 bytes; the
+		// import map grows with chunk count, so it goes after the charset.
+		expect(charsetIdx).toBeLessThan(mapIdx);
+	});
+
+	it("keeps a leading meta charset ahead of the import map and modulepreload links in default preload mode", async () => {
+		const plugin = sri({ algorithm: "sha256" }) as any;
+		plugin.configResolved?.({ base: "/", build: { ssr: false } } as any);
+		const bundle: Record<string, Chunk | Asset> = {
+			"index.html": {
+				type: "asset",
+				source: '<!doctype html><html><head><meta charset="utf-8"></head><body></body></html>',
+			},
+			"assets/entry.js": makeEntryChunk({
+				code: "const p = import('./lazy.js');",
+				dynamicImports: ["src/lazy.ts"],
+			}),
+			"assets/lazy.js": makeDynChunk("assets/lazy.js", "src/lazy.ts"),
+		} as any;
+		await plugin.generateBundle.handler({}, bundle as any);
+		const html = String((bundle["index.html"] as Asset).source);
+		const charsetIdx = html.indexOf("<meta charset");
+		const mapIdx = html.indexOf('<script type="importmap">');
+		const preloadIdx = html.indexOf('rel="modulepreload"');
+		expect(charsetIdx).toBeGreaterThan(-1);
+		expect(mapIdx).toBeGreaterThan(-1);
+		expect(preloadIdx).toBeGreaterThan(-1);
+		// charset first, then the import map, then the preload links — the
+		// map must still precede every modulepreload link and module script.
+		expect(charsetIdx).toBeLessThan(mapIdx);
+		expect(mapIdx).toBeLessThan(preloadIdx);
+	});
+
+	it("injects the import map at the start of head when no charset meta is present", async () => {
+		const { plugin, bundle } = buildPluginBundle(
+			"/",
+			"<!doctype html><html><head><title>t</title></head><body></body></html>"
+		);
+		await plugin.generateBundle.handler({}, bundle as any);
+		const html = String((bundle["index.html"] as Asset).source);
+		const headIdx = html.indexOf("<head>");
+		const mapIdx = html.indexOf('<script type="importmap">');
+		const titleIdx = html.indexOf("<title>");
+		expect(mapIdx).toBe(headIdx + "<head>".length);
+		expect(mapIdx).toBeLessThan(titleIdx);
+	});
 });

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -2129,7 +2129,7 @@ describe("vite-plugin-sri-gen", () => {
 			expect(rewriteDynamicImports("")).toBe("");
 		});
 
-		it("rewrites import() in chunks and enables enforceDynamicImports in the runtime when preload injection is disabled", async () => {
+		it("rewrites import() in chunks and enables enforceDynamicImports in the runtime when preload injection is disabled (manifest-only bundle)", async () => {
 			const plugin = sri({
 				algorithm: "sha256",
 				preloadDynamicChunks: false,
@@ -2138,7 +2138,12 @@ describe("vite-plugin-sri-gen", () => {
 			plugin.configResolved?.({ base: "/", build: { ssr: false } } as any);
 
 			const bundle: Record<string, Chunk | Asset> = {
-				"index.html": { type: "asset", source: htmlDoc("") },
+				".vite/manifest.json": {
+					type: "asset",
+					source: JSON.stringify({
+						"src/main.ts": { file: "assets/entry.js" },
+					}),
+				},
 				"assets/entry.js": makeEntryChunk({
 					code: "const p = import('./lazy.js'); console.log(p);",
 					dynamicImports: ["src/lazy.ts"],
@@ -2243,7 +2248,12 @@ describe("vite-plugin-sri-gen", () => {
 			plugin.configResolved?.({ base: "/", build: { ssr: false } } as any);
 
 			const bundle: Record<string, Chunk | Asset> = {
-				"index.html": { type: "asset", source: htmlDoc("") },
+				".vite/manifest.json": {
+					type: "asset",
+					source: JSON.stringify({
+						"src/main.ts": { file: "assets/entry.js" },
+					}),
+				},
 				"assets/entry.js": makeEntryChunk({
 					code: "const a = import('./outer.js');",
 				}),
@@ -2281,7 +2291,12 @@ describe("vite-plugin-sri-gen", () => {
 			lazy.map = { version: 3, sources: ["lazy.ts"], mappings: "AAAA" };
 
 			const bundle: Record<string, Chunk | Asset> = {
-				"index.html": { type: "asset", source: htmlDoc("") },
+				".vite/manifest.json": {
+					type: "asset",
+					source: JSON.stringify({
+						"src/main.ts": { file: "assets/entry.js" },
+					}),
+				},
 				"assets/entry.js": entry,
 				"assets/lazy.js": lazy,
 			} as any;
@@ -2301,8 +2316,13 @@ describe("vite-plugin-sri-gen", () => {
 			plugin.configResolved?.({ base: "/", build: { ssr: false } } as any);
 
 			const bundle: Record<string, Chunk | Asset> = {
-				"index.html": { type: "asset", source: htmlDoc("") },
-				"about.html": { type: "asset", source: htmlDoc("") },
+				".vite/manifest.json": {
+					type: "asset",
+					source: JSON.stringify({
+						"src/a.ts": { file: "assets/entry-a.js" },
+						"src/b.ts": { file: "assets/entry-b.js" },
+					}),
+				},
 				"assets/entry-a.js": makeEntryChunk({
 					fileName: "assets/entry-a.js",
 					code: "const a = import('./shared.js');",
@@ -2342,6 +2362,10 @@ describe("vite-plugin-sri-gen", () => {
 			expect(out).not.toContain("__sriImport");
 		});
 
+		// NOTE: with HTML in the bundle the import map subsumes JS-level
+		// enforcement, so no rewrite occurs here — the round-trip still
+		// verifies that the HTML integrity attribute matches the final
+		// (runtime-prepended) entry chunk bytes.
 		it("entry chunk hash reflects post-rewrite, post-runtime bytes (round-trip)", async () => {
 			const plugin = sri({
 				algorithm: "sha256",

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -2663,4 +2663,152 @@ describe("import map SRI", () => {
 			mappings: "AAAA",
 		});
 	});
+
+	it("excludes skipResources-matched chunks from the import map integrity object", async () => {
+		const plugin = sri({
+			algorithm: "sha256",
+			preloadDynamicChunks: false,
+			runtimePatchDynamicLinks: true,
+			skipResources: ["**/vendor.js"],
+		}) as any;
+		plugin.configResolved?.({ base: "/", build: { ssr: false } } as any);
+		const bundle: Record<string, Chunk | Asset> = {
+			"index.html": { type: "asset", source: htmlDoc("") },
+			"assets/entry.js": makeEntryChunk({ code: "" }),
+			"assets/vendor.js": makeDynChunk("assets/vendor.js", "src/vendor.ts"),
+		} as any;
+		await plugin.generateBundle.handler({}, bundle as any);
+		const html = String((bundle["index.html"] as Asset).source);
+		const m = html.match(/<script type="importmap">([\s\S]*?)<\/script>/);
+		const parsed = JSON.parse(m![1]);
+		expect(parsed.integrity["/assets/entry.js"]).toMatch(/^sha256-/);
+		expect(parsed.integrity["/assets/vendor.js"]).toBeUndefined();
+	});
+
+	it("injects integrity into an existing import map element that has no text content", async () => {
+		const existing = '<script type="importmap"></script>';
+		const { plugin, bundle } = buildPluginBundle(
+			"/",
+			`<!doctype html><html><head>${existing}</head><body></body></html>`
+		);
+		await plugin.generateBundle.handler({}, bundle as any);
+		const html = String((bundle["index.html"] as Asset).source);
+		const maps = html.match(/<script type="importmap">/g) ?? [];
+		expect(maps.length).toBe(1);
+		const m = html.match(/<script type="importmap">([\s\S]*?)<\/script>/);
+		const parsed = JSON.parse(m![1]);
+		expect(parsed.integrity["/assets/entry.js"]).toMatch(/^sha256-/);
+		expect(parsed.integrity["/assets/lazy.js"]).toMatch(/^sha256-/);
+	});
+
+	it("uses absolute CDN URLs as import map keys when base is an absolute URL", async () => {
+		const plugin = sri({
+			algorithm: "sha256",
+			preloadDynamicChunks: false,
+			runtimePatchDynamicLinks: true,
+		}) as any;
+		plugin.configResolved?.({
+			base: "https://cdn.example.com/",
+			build: { ssr: false },
+		} as any);
+		const bundle: Record<string, Chunk | Asset> = {
+			"index.html": { type: "asset", source: htmlDoc("") },
+			"assets/entry.js": makeEntryChunk({ code: "" }),
+			"assets/lazy.js": makeDynChunk("assets/lazy.js", "src/lazy.ts"),
+		} as any;
+		await plugin.generateBundle.handler({}, bundle as any);
+		const html = String((bundle["index.html"] as Asset).source);
+		const m = html.match(/<script type="importmap">([\s\S]*?)<\/script>/);
+		expect(m).toBeTruthy();
+		const parsed = JSON.parse(m![1]);
+		expect(
+			parsed.integrity["https://cdn.example.com/assets/entry.js"]
+		).toMatch(/^sha256-/);
+		expect(
+			parsed.integrity["https://cdn.example.com/assets/lazy.js"]
+		).toMatch(/^sha256-/);
+		expect(parsed.integrity["/assets/entry.js"]).toBeUndefined();
+	});
+
+	it("injects the import map even when runtimePatchDynamicLinks is false", async () => {
+		const plugin = sri({
+			algorithm: "sha256",
+			preloadDynamicChunks: false,
+			runtimePatchDynamicLinks: false,
+		}) as any;
+		plugin.configResolved?.({ base: "/", build: { ssr: false } } as any);
+		const bundle: Record<string, Chunk | Asset> = {
+			"index.html": { type: "asset", source: htmlDoc("") },
+			"assets/entry.js": makeEntryChunk({
+				code: "const p = import('./lazy.js');",
+			}),
+			"assets/lazy.js": makeDynChunk("assets/lazy.js", "src/lazy.ts"),
+		} as any;
+		await plugin.generateBundle.handler({}, bundle as any);
+		const html = String((bundle["index.html"] as Asset).source);
+		const m = html.match(/<script type="importmap">([\s\S]*?)<\/script>/);
+		expect(m).toBeTruthy();
+		const parsed = JSON.parse(m![1]);
+		expect(parsed.integrity["/assets/entry.js"]).toMatch(/^sha256-/);
+		expect(
+			(bundle["assets/entry.js"] as Chunk).code
+		).not.toContain("installSriRuntime");
+	});
+
+	it("keeps the JS enforcement rewrite when a manifest is emitted alongside HTML (mixed-bundle consumers)", async () => {
+		const plugin = sri({
+			algorithm: "sha256",
+			preloadDynamicChunks: false,
+			runtimePatchDynamicLinks: true,
+		}) as any;
+		plugin.configResolved?.({ base: "/", build: { ssr: false } } as any);
+		const bundle: Record<string, Chunk | Asset> = {
+			"index.html": { type: "asset", source: htmlDoc("") },
+			".vite/manifest.json": {
+				type: "asset",
+				source: JSON.stringify({
+					"src/main.ts": { file: "assets/entry.js" },
+				}),
+			},
+			"assets/entry.js": makeEntryChunk({
+				code: "const p = import('./lazy.js');",
+				dynamicImports: ["src/lazy.ts"],
+			}),
+			"assets/lazy.js": makeDynChunk("assets/lazy.js", "src/lazy.ts"),
+		} as any;
+		await plugin.generateBundle.handler({}, bundle as any);
+		// Manifest consumers render their own HTML without the import map, so
+		// the JS-level enforcement path must remain active for them.
+		const entryCode = (bundle["assets/entry.js"] as Chunk).code;
+		expect(entryCode).toContain("__sriImport(import.meta.url, './lazy.js')");
+		expect(entryCode).toContain("enforceDynamicImports: true");
+		// The emitted HTML still gets the import map (covers its own pages).
+		const html = String((bundle["index.html"] as Asset).source);
+		expect(html).toContain('<script type="importmap">');
+	});
+
+	it("warns when an existing import map pins an integrity value that differs from the computed hash", async () => {
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		try {
+			const existing =
+				'<script type="importmap">{"integrity":{"/assets/entry.js":"sha256-USER"}}</script>';
+			const { plugin, bundle } = buildPluginBundle(
+				"/",
+				`<!doctype html><html><head>${existing}</head><body></body></html>`
+			);
+			await plugin.generateBundle.handler({}, bundle as any);
+			expect(warnSpy).toHaveBeenCalledWith(
+				expect.stringContaining(
+					"differs from the build-computed hash"
+				)
+			);
+			// The user's entry is still kept (documented precedence).
+			const html = String((bundle["index.html"] as Asset).source);
+			const m = html.match(/<script type="importmap">([\s\S]*?)<\/script>/);
+			const parsed = JSON.parse(m![1]);
+			expect(parsed.integrity["/assets/entry.js"]).toBe("sha256-USER");
+		} finally {
+			warnSpy.mockRestore();
+		}
+	});
 });

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -2529,3 +2529,114 @@ describe("buildSriRuntimeCode (issue #30: self-contained injected runtime)", () 
 		expect(sandbox.r).toBe("</script>");
 	});
 });
+
+describe("import map SRI", () => {
+	function buildPluginBundle(base = "/", html = htmlDoc("")) {
+		const plugin = sri({
+			algorithm: "sha256",
+			preloadDynamicChunks: false,
+			runtimePatchDynamicLinks: true,
+		}) as any;
+		plugin.configResolved?.({ base, build: { ssr: false } } as any);
+		const bundle: Record<string, Chunk | Asset> = {
+			"index.html": { type: "asset", source: html },
+			"assets/entry.js": makeEntryChunk({
+				code: "const p = import('./lazy.js');",
+				dynamicImports: ["src/lazy.ts"],
+			}),
+			"assets/lazy.js": makeDynChunk("assets/lazy.js", "src/lazy.ts"),
+		} as any;
+		return { plugin, bundle };
+	}
+
+	it("injects an import map with integrity entries for every JS chunk", async () => {
+		const { plugin, bundle } = buildPluginBundle();
+		await plugin.generateBundle.handler({}, bundle as any);
+		const html = String((bundle["index.html"] as Asset).source);
+		const m = html.match(/<script type="importmap">([\s\S]*?)<\/script>/);
+		expect(m).toBeTruthy();
+		const parsed = JSON.parse(m![1]);
+		expect(parsed.integrity["/assets/entry.js"]).toMatch(/^sha256-/);
+		expect(parsed.integrity["/assets/lazy.js"]).toMatch(/^sha256-/);
+	});
+
+	it("does not rewrite import() and disables runtime enforcement when the import map is emitted", async () => {
+		const { plugin, bundle } = buildPluginBundle();
+		await plugin.generateBundle.handler({}, bundle as any);
+		const entryCode = (bundle["assets/entry.js"] as Chunk).code;
+		expect(entryCode).toContain("import('./lazy.js')");
+		expect(entryCode).not.toContain("__sriImport(import.meta.url");
+		expect(entryCode).toContain("enforceDynamicImports: false");
+		expect(entryCode).toContain("installSriRuntime"); // DOM patching stays
+	});
+
+	it("injects the import map in default preload mode too, before modulepreload links", async () => {
+		const plugin = sri({ algorithm: "sha256" }) as any;
+		plugin.configResolved?.({ base: "/", build: { ssr: false } } as any);
+		const bundle: Record<string, Chunk | Asset> = {
+			"index.html": { type: "asset", source: htmlDoc("") },
+			"assets/entry.js": makeEntryChunk({
+				code: "const p = import('./lazy.js');",
+				dynamicImports: ["src/lazy.ts"],
+			}),
+			"assets/lazy.js": makeDynChunk("assets/lazy.js", "src/lazy.ts"),
+		} as any;
+		await plugin.generateBundle.handler({}, bundle as any);
+		const html = String((bundle["index.html"] as Asset).source);
+		const mapIdx = html.indexOf('<script type="importmap">');
+		const preloadIdx = html.indexOf('rel="modulepreload"');
+		expect(mapIdx).toBeGreaterThan(-1);
+		expect(preloadIdx).toBeGreaterThan(-1);
+		expect(mapIdx).toBeLessThan(preloadIdx);
+	});
+
+	it("merges integrity into an existing import map without overwriting user entries", async () => {
+		const existing =
+			'<script type="importmap">{"imports":{"lodash":"/vendor/lodash.js"},"integrity":{"/assets/entry.js":"sha256-USER"}}</script>';
+		const { plugin, bundle } = buildPluginBundle(
+			"/",
+			`<!doctype html><html><head>${existing}</head><body></body></html>`
+		);
+		await plugin.generateBundle.handler({}, bundle as any);
+		const html = String((bundle["index.html"] as Asset).source);
+		const maps = html.match(/<script type="importmap">/g) ?? [];
+		expect(maps.length).toBe(1); // merged, not duplicated
+		const m = html.match(/<script type="importmap">([\s\S]*?)<\/script>/);
+		const parsed = JSON.parse(m![1]);
+		expect(parsed.imports.lodash).toBe("/vendor/lodash.js"); // preserved
+		expect(parsed.integrity["/assets/entry.js"]).toBe("sha256-USER"); // user wins
+		expect(parsed.integrity["/assets/lazy.js"]).toMatch(/^sha256-/); // ours added
+	});
+
+	it("skips injection and keeps the runtime enforcement path for relative base", async () => {
+		const { plugin, bundle } = buildPluginBundle("./");
+		await plugin.generateBundle.handler({}, bundle as any);
+		const html = String((bundle["index.html"] as Asset).source);
+		expect(html).not.toContain("importmap");
+		const entryCode = (bundle["assets/entry.js"] as Chunk).code;
+		expect(entryCode).toContain("__sriImport(import.meta.url");
+		expect(entryCode).toContain("enforceDynamicImports: true");
+	});
+
+	it("leaves HTML untouched when an existing import map has malformed JSON", async () => {
+		const existing = '<script type="importmap">{not json}</script>';
+		const { plugin, bundle } = buildPluginBundle(
+			"/",
+			`<!doctype html><html><head>${existing}</head><body></body></html>`
+		);
+		await plugin.generateBundle.handler({}, bundle as any);
+		const html = String((bundle["index.html"] as Asset).source);
+		expect(html).toContain("{not json}"); // unmodified
+		const maps = html.match(/<script type="importmap">/g) ?? [];
+		expect(maps.length).toBe(1); // no second map added
+	});
+
+	it("preserves source maps when the rewrite is skipped (HTML present)", async () => {
+		const { plugin, bundle } = buildPluginBundle();
+		(bundle["assets/entry.js"] as any).map = { mappings: "AAAA" };
+		await plugin.generateBundle.handler({}, bundle as any);
+		expect((bundle["assets/entry.js"] as any).map).toEqual({
+			mappings: "AAAA",
+		});
+	});
+});

--- a/test/internal.spec.ts
+++ b/test/internal.spec.ts
@@ -16,6 +16,8 @@ import {
 	IntegrityProcessor,
 	isEligibleForSri,
 	isHttpUrl,
+	isImportMapCapableBase,
+	buildImportIntegrityObject,
 	joinBaseHref,
 	loadResource,
 	ManifestProcessor,
@@ -132,6 +134,66 @@ describe("Internal Utility Functions", () => {
 
 		it("falls through to path.posix.join for empty base", () => {
 			expect(joinBaseHref("", "chunk.js")).toBe("chunk.js");
+		});
+	});
+
+	describe("isImportMapCapableBase", () => {
+		it("accepts root-relative and absolute-URL bases", () => {
+			expect(isImportMapCapableBase("/")).toBe(true);
+			expect(isImportMapCapableBase("/app/")).toBe(true);
+			expect(isImportMapCapableBase("https://cdn.example.com/")).toBe(true);
+			expect(isImportMapCapableBase("//cdn.example.com/")).toBe(true);
+		});
+
+		it("rejects relative and empty bases (keys would be bare specifiers)", () => {
+			expect(isImportMapCapableBase("./")).toBe(false);
+			expect(isImportMapCapableBase("../nested/")).toBe(false);
+			expect(isImportMapCapableBase("")).toBe(false);
+		});
+	});
+
+	describe("buildImportIntegrityObject", () => {
+		const map = {
+			"/assets/entry.js": "sha384-AAA",
+			"/assets/chunk-B.mjs": "sha384-BBB",
+			"/assets/style.css": "sha384-CCC",
+		};
+
+		it("maps JS/MJS pathnames to base-joined URL keys with base '/'", () => {
+			expect(buildImportIntegrityObject(map, "/")).toEqual({
+				"/assets/entry.js": "sha384-AAA",
+				"/assets/chunk-B.mjs": "sha384-BBB",
+			});
+		});
+
+		it("prefixes sub-path base", () => {
+			expect(buildImportIntegrityObject(map, "/app/")).toEqual({
+				"/app/assets/entry.js": "sha384-AAA",
+				"/app/assets/chunk-B.mjs": "sha384-BBB",
+			});
+		});
+
+		it("produces absolute URL keys for CDN base", () => {
+			expect(
+				buildImportIntegrityObject(map, "https://cdn.example.com/")
+			).toEqual({
+				"https://cdn.example.com/assets/entry.js": "sha384-AAA",
+				"https://cdn.example.com/assets/chunk-B.mjs": "sha384-BBB",
+			});
+		});
+
+		it("returns null for relative bases", () => {
+			expect(buildImportIntegrityObject(map, "./")).toBeNull();
+			expect(buildImportIntegrityObject(map, "")).toBeNull();
+		});
+
+		it("excludes non-module assets and returns {} when nothing qualifies", () => {
+			expect(
+				buildImportIntegrityObject(
+					{ "/assets/style.css": "sha384-CCC" },
+					"/"
+				)
+			).toEqual({});
 		});
 
 		it("strips leading slash from chunk file with absolute URL base", () => {

--- a/test/internal.spec.ts
+++ b/test/internal.spec.ts
@@ -196,6 +196,31 @@ describe("Internal Utility Functions", () => {
 			).toEqual({});
 		});
 
+		it("excludes entries matching skipResources patterns", () => {
+			expect(
+				buildImportIntegrityObject(map, "/", ["**/chunk-B.mjs"])
+			).toEqual({
+				"/assets/entry.js": "sha384-AAA",
+			});
+			// Patterns written with a leading slash also match
+			expect(
+				buildImportIntegrityObject(map, "/", ["/assets/entry.js"])
+			).toEqual({
+				"/assets/chunk-B.mjs": "sha384-BBB",
+			});
+		});
+
+		it("includes JS pathnames carrying a query suffix (PROCESSABLE_EXTENSIONS parity)", () => {
+			expect(
+				buildImportIntegrityObject(
+					{ "/assets/entry.js?v=1": "sha384-QQQ" },
+					"/"
+				)
+			).toEqual({
+				"/assets/entry.js?v=1": "sha384-QQQ",
+			});
+		});
+
 		it("strips leading slash from chunk file with absolute URL base", () => {
 			expect(
 				joinBaseHref("https://cdn.myapp.com/", "/assets/chunk.js")


### PR DESCRIPTION
## Summary

Adopts the import map [`integrity`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap#integrity_metadata_map) key (Chrome 127+, Firefox 138+, Safari 18+) as the primary SRI mechanism for ES module chunks, with no new configuration options, selection is dynamic at build-time.

- **Always injects** (or merges into an existing) `<script type="importmap">` with an `integrity` object covering every emitted JS module chunk, into each emitted HTML file, in both preload modes. Placed first in `<head>`, before any modulepreload link or module script. User-authored integrity entries win on merge conflicts; malformed existing maps are left untouched with a warning.
- **Subsumes the JS-level `__sriImport` path** wherever the import map is emitted: with `preloadDynamicChunks: false` + HTML + a root-relative/absolute `base`, the `import()` rewrite and runtime enforcement block are disabled. The browser enforces SRI natively on static **and** dynamic module imports.
- **Keeps the runtime fallback automatically** where import maps are impossible: manifest-only bundles (backend-owned HTML) and relative-base builds behave exactly as before.
- The DOM-patching runtime (`runtimePatchDynamicLinks`) is unaffected, separate responsibility.

### Why

The `__sriImport` runtime (issues #30/#32) existed because `import()` had no way to carry integrity metadata. The platform closed that gap. Native enforcement via the import map:

- eliminates the double fetch (verification `fetch` + module fetch), verified end-to-end: one request per lazy chunk,
- fully closes the documented fetch-vs-import TOCTOU window,
- covers **static** inter-chunk imports, including the dynamically-imported-facade re-export gap noted in #32 (modulepreload discovery is one-level and misses those),
- removes the secure-context (`crypto.subtle`) requirement and source-map dropping in import-map-covered builds.

### Behavior change (heads-up)

Consumers with `preloadDynamicChunks: false` + emitted HTML move from fail-closed JS verification on all browsers to native enforcement on Chrome 127+/Firefox 138+/Safari 18+, **fail-open on older browsers**, consistent with how SRI degrades platform-wide (HTML `integrity` attributes and modulepreload links are likewise ignored by non-supporting browsers). Documented in the README's new "Import Map Integrity" section, along with the CSP note (the import map is an inline script) and the workers caveat.

## Test Plan

- [x] 410/410 vitest tests pass, eslint clean , includes new unit tests (key building across `/`, `/app/`, CDN, and relative bases) and integration tests (injection in both modes, placement before modulepreload links, merge semantics, malformed-map handling, rewrite-skip, source-map preservation, runtime fallback for relative base)
- [x] Four pre-existing rewrite tests converted to manifest-only bundles (the rewrite path's remaining scope)
- [x] E2E in headless Chrome against a real Vite 7 build (nested dynamic imports, `assets/js/` layout): single fetch per chunk, nested import loads; tampered chunk **blocked natively by the browser** ("Failed to find a valid digest in the 'integrity' attribute… The resource has been blocked"); `base: '/app/'` sub-path works; hand-written import map in the template is merged into a single map

## Post-review hardening

A 6-agent review pass (injection correctness, gating matrix, security, tests, docs, regressions) produced these fixes, all included:

- **`skipResources` is now honored by the import map** — opted-out chunks no longer receive native enforcement they were excluded from elsewhere
- **Mixed HTML+manifest bundles keep the JS enforcement rewrite** — manifest consumers render their own HTML without the import map, so the rewrite suppression now also requires `!hasManifestFiles`
- Build-time warnings for: a user-pinned import-map integrity value that differs from the computed hash, and an absolute-URL `<base href>` in user HTML (changes key resolution)
- Safari support corrected to **18+** per MDN browser-compat-data (18.4 is the adjacent multiple-import-maps feature)
- Query-suffix key-filter parity with `PROCESSABLE_EXTENSIONS`, single shared `escapeForScript`, once-per-build relative-base log
- 8 new tests (418 total)

- **`<meta charset>` stays first in `<head>`** — the injected import map and modulepreload links grow with chunk count and previously displaced the charset declaration past the spec's 1024-byte window; both now insert after a leading charset meta (map still precedes every link/module script)
