### PR TITLE
Update used actions, use NodeJS 24 eveywhere

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,10 +17,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
-          node-version: "20.x"
+          node-version: "24"
+          cache: "npm"
       - name: Install Dependencies
         run: npm ci
       - name: Build

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,19 +18,19 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
-          node-version: "22.x"
+          node-version: "24"
           cache: "npm"
       - name: Install Dependencies
         run: npm ci
       - name: Build Docs
         run: npm run docs:build
-      - uses: actions/configure-pages@v5
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/configure-pages@v6
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: docs/.vitepress/dist
   deploy:
@@ -45,4 +45,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,12 +9,13 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: main
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: "24"
+          cache: "npm"
           registry-url: "https://registry.npmjs.org"
       - name: Update version from release tag
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,15 +17,15 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
-          node-version: "20.x"
+          node-version: "24"
           cache: "npm"
       - run: npm ci
       - name: Run Unit Tests
         run: npm run test:cov
       - name: Upload Test Coverage to Codecov
-        uses: codecov/codecov-action@v4.0.1
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Current jobs issue a deprecation warning due to outdated actions using NodeJS 20.

<img width="1243" height="409" alt="image" src="https://github.com/user-attachments/assets/3ea3c862-abd5-4bac-aa6d-a365c160d899" />

This PR updates all used actions and use NodeJS 24 for consistency between all CI steps.