### PR TITLE
fix: deliver module-graph SRI without an inline import map under strict CSP

### DIFF
--- a/docs/configure/options.md
+++ b/docs/configure/options.md
@@ -12,6 +12,7 @@ interface SriPluginOptions {
   crossorigin?: 'anonymous' | 'use-credentials'
   fetchCache?: boolean
   fetchTimeoutMs?: number
+  importMapIntegrity?: boolean
   preloadDynamicChunks?: boolean
   runtimePatchDynamicLinks?: boolean
   skipResources?: string[]
@@ -27,6 +28,7 @@ interface SriPluginOptions {
 | `crossorigin` | `'anonymous' \| 'use-credentials'` | `undefined` | CORS attribute added to integrity-enabled elements |
 | `fetchCache` | `boolean` | `true` | Cache remote fetches in-memory and deduplicate concurrent requests |
 | `fetchTimeoutMs` | `number` | `5000` | Abort remote fetches after N ms; `0` disables the timeout |
+| `importMapIntegrity` | `boolean` | `true` | Deliver module-graph integrity via an inline `<script type="importmap">`. Set `false` for a strict CSP with no `'unsafe-inline'` |
 | `preloadDynamicChunks` | `boolean` | `true` | Inject `<link rel="modulepreload" integrity=...>` for dynamically imported chunks |
 | `runtimePatchDynamicLinks` | `boolean` | `true` | Prepend a small runtime to entry chunks that adds integrity to dynamically created elements |
 | `skipResources` | `string[]` | `[]` | Patterns (exact or glob) matched against element `id`, `src`, or `href`; matching resources are excluded from SRI |
@@ -128,6 +130,41 @@ export default {
 ```
 
 See [Networking](/configure/networking) for more detail on timeout behavior.
+
+## `importMapIntegrity`
+
+Controls whether module-graph integrity is delivered through an inline `<script type="importmap">`.
+
+**Default:** `true`
+
+Import maps must be inline — the HTML spec forbids `src` on `<script type="importmap">`, and external import maps have never shipped in any browser. So a `Content-Security-Policy` whose `script-src` omits `'unsafe-inline'` blocks the injected map. Nothing appears broken when this happens: the map carries only an `integrity` key, so module resolution never depended on it. What is lost, silently, is SRI on every chunk the map was the only cover for.
+
+Set this to `false` when your CSP does not permit inline scripts:
+
+```ts
+// vite.config.ts
+import sri from 'vite-plugin-sri-gen'
+
+export default {
+  plugins: [
+    sri({
+      // No inline script is emitted; the same hashes ship as
+      // <link rel="modulepreload" integrity=...> instead.
+      importMapIntegrity: false,
+    }),
+  ],
+}
+```
+
+Coverage is preserved rather than reduced, **provided `preloadDynamicChunks` stays at its default `true`** — that is the channel the hashes move to. With the map disabled, modulepreload injection widens from "dynamically imported chunks" to the whole module graph, so chunks reached only by a static `import` inside a lazy chunk — which have no HTML element of their own and cannot be annotated at the import site — stay verified. `importMapIntegrity: false` + `preloadDynamicChunks: true` is the one configuration that satisfies a strict CSP with no gaps and no server coordination.
+
+Turning both off leaves chunks reached only by a static import with no channel at all. The `import()` rewrite is not a substitute — it hooks call sites, and a static import is not a call site. The build warns when this would actually leave chunks uncovered, naming the count.
+
+The tradeoff is eager fetching: those chunks are downloaded when the HTML is parsed rather than when the lazy route needs them.
+
+**Single-page apps.** The increment is usually modest, because `preloadDynamicChunks` (on by default) already preloads the lazy chunks themselves; what gets added is their private dependencies.
+
+**Multi-page apps.** The widened set is computed per bundle, not per page, so every emitted HTML file receives preload links for every module-graph chunk in the build — including chunks private to other pages. The import map has always had this same bundle-wide scope, but as inert bytes in an inline script; as preload links it becomes real network fetches. On an MPA with large, independent per-page graphs, measure before adopting.
 
 ## `preloadDynamicChunks`
 

--- a/docs/configure/skipping-resources.md
+++ b/docs/configure/skipping-resources.md
@@ -74,6 +74,7 @@ Typical resources to exclude:
 A `skipResources` exclusion is applied consistently across every mechanism the plugin uses. A skipped resource receives no integrity attribute in:
 
 - **Static HTML tags** — `<script>`, `<link rel="stylesheet">`, `<link rel="modulepreload">` found in your HTML at build time
+- **Injected modulepreload links** — a skipped chunk gets no `<link rel="modulepreload">` of its own, whether it reached the preload set as a dynamic import target or through the widened set of [`importMapIntegrity: false`](/configure/options#importmapintegrity)
 - **The import map** — the `integrity` object inside the injected `<script type="importmap">` (see [Import Map Integrity](/integrate/import-map))
 - **Runtime patching** — the built-in integrity map passed to the injected runtime, so dynamically created elements for skipped resources are also left alone (see [Runtime Patching](/integrate/runtime-patching))
 - **Manifest entries** — the `integrity` and `cssIntegrity` fields added to Vite manifest entries (see [Backend-Owned HTML (Manifest)](/integrate/backend-manifest))

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -43,14 +43,14 @@ export default {
 }
 ```
 
-See [Options](/configure/options) for the full reference, including `preloadDynamicChunks` and `runtimePatchDynamicLinks`.
+See [Options](/configure/options) for the full reference, including `importMapIntegrity`, `preloadDynamicChunks`, and `runtimePatchDynamicLinks`.
 
 ## What You Get
 
 Running `vite build` with this plugin produces HTML where every relevant tag carries a computed integrity hash:
 
 - **Scripts, stylesheets, and modulepreload links** already present in your HTML get `integrity` (and `crossorigin`, if configured) added automatically. See [Coverage Strategies](/learn/coverage-strategies).
-- **import map integrity** — an injected `<script type="importmap">` declares hashes for the JS modules reached through the module graph (not already covered by a tag's own `integrity`), giving supported modern browsers native SRI enforcement over both static and dynamic module imports. Builds with no code splitting need no import map at all. See [Import Map Integrity](/integrate/import-map).
+- **import map integrity** — an injected `<script type="importmap">` declares hashes for the JS modules reached through the module graph (not already covered by a tag's own `integrity`), giving supported modern browsers native SRI enforcement over both static and dynamic module imports. Builds with no code splitting need no import map at all. Import maps must be inline, so a `script-src` without `'unsafe-inline'` blocks this one — set [`importMapIntegrity: false`](/configure/options#importmapintegrity) to deliver the same hashes as modulepreload links instead. See [Import Map Integrity](/integrate/import-map).
 - **Modulepreload injection for lazy chunks** — the plugin scans Rollup output for dynamically imported chunks and injects `<link rel="modulepreload" integrity=...>` links into each HTML file, so lazy chunks are preloaded with verified hashes. See [Coverage Strategies](/learn/coverage-strategies).
 - **CSP-safe runtime patching of dynamic tags** — a tiny runtime prepended to entry chunks intercepts dynamically created `<script>` and `<link>` elements and adds the appropriate `integrity` and `crossorigin` attributes before the browser makes the request. See [Runtime Patching](/integrate/runtime-patching).
 - **Vite manifest augmentation** — when `build.manifest: true` is set, the plugin adds `integrity` and `cssIntegrity` fields to each manifest entry so backends that own HTML generation can attach integrity without re-hashing the files. See [Backend-Owned HTML (Manifest)](/integrate/backend-manifest).

--- a/docs/integrate/import-map.md
+++ b/docs/integrate/import-map.md
@@ -38,10 +38,22 @@ If your HTML already declares a `<script type="importmap">`, the plugin merges i
 
 ## CSP Considerations
 
-Import maps are necessarily inline — the HTML spec does not allow a `src` attribute on `<script type="importmap">`. A strict `Content-Security-Policy` with `script-src` that excludes `'unsafe-inline'` must permit the map via either:
+Import maps are necessarily inline — the HTML spec does not allow a `src` attribute on `<script type="importmap">`, and external import maps have never shipped in any browser. A strict `Content-Security-Policy` with `script-src` that excludes `'unsafe-inline'` will block the map.
 
-- **A nonce** — your server templating injects a fresh nonce into both the CSP header and the `<script>` tag. This is the recommended approach.
-- **A hash** — the browser can hash the inline script and match it against a `script-src` hash value. Note that the import map's content includes chunk content hashes, so it changes on every build. Automating hash extraction and CSP header updates is required.
+**The failure is silent.** The injected map has no `imports` key, only `integrity`, so module resolution never depended on it — the app loads exactly as before. All that is lost is SRI on the chunks the map alone covered.
+
+The direct fix is to stop using the inline channel:
+
+```ts
+sri({ importMapIntegrity: false })
+```
+
+The plugin then emits no inline script and delivers the same hashes as `<link rel="modulepreload" integrity=...>`, which `script-src` does not govern. Coverage is preserved, including the static-import chunks the map used to cover alone — provided `preloadDynamicChunks` stays at its default `true`, since that is the channel the hashes move to. See [`importMapIntegrity`](/configure/options#importmapintegrity) for the eager-fetch tradeoff and multi-page considerations.
+
+To keep the map instead, permit it via:
+
+- **A nonce** — your server templating injects a fresh nonce into both the CSP header and the `<script>` tag. Nothing to update after a build.
+- **A hash** — the browser hashes the inline script and matches it against a `script-src` hash value. The map contains chunk content hashes, so it changes every build; hash extraction and CSP header updates must be automated in your deploy pipeline.
 
 If your build has no code splitting, none of this applies — see above, no import map is injected in the first place, so there's nothing to whitelist.
 
@@ -50,6 +62,8 @@ If your build has no code splitting, none of this applies — see above, no impo
 - **Workers and Service Workers** — import maps do not apply inside Web Workers or Service Workers. Module chunks loaded there are not covered by the import map, and the JS-runtime fallback does not cover them either. See [Limitations](/troubleshoot/limitations).
 
 - **Relative `base`** — with `base: './'`, `''`, or any `'../…'` value, import map keys cannot be expressed portably (keys resolve against each document's URL and differ per page). Injection is skipped for relative base configurations. The JS-runtime fallback remains active for `preloadDynamicChunks: false` builds. See [Coverage Strategies](/learn/coverage-strategies) for the full decision tree.
+
+  With no map and only the default narrow preloads, a chunk reached solely by a static `import` inside a lazy chunk is left unverified — the JS-runtime fallback hooks `import()` call sites and a static import is not one. The build warns and names the affected chunks. Setting [`importMapIntegrity: false`](/configure/options#importmapintegrity) closes this: the widened modulepreload set is base-shape agnostic, so it works for relative bases even though the option is framed around CSP.
 
 - **`skipResources` patterns** — resources excluded via `skipResources` are also excluded from the import map. The opt-out applies to native module-fetch enforcement as well.
 

--- a/docs/integrate/spa-mpa.md
+++ b/docs/integrate/spa-mpa.md
@@ -48,7 +48,11 @@ export default defineConfig({
 })
 ```
 
-Every emitted HTML file — `index.html`, `about/index.html`, and `admin/index.html` — receives SRI attributes. Each page's static tags are hashed independently; the import map and any injected modulepreload links reflect the chunks that page actually loads.
+Every emitted HTML file — `index.html`, `about/index.html`, and `admin/index.html` — receives SRI attributes. Each page's static tags are hashed independently.
+
+::: warning Injected coverage is bundle-wide, not per-page
+The import map and any injected modulepreload links are computed once for the whole bundle and written into every page, so each HTML file declares hashes for chunks that only other pages load. For the import map this costs a few extra bytes in an inline script. If you set [`importMapIntegrity: false`](/configure/options#importmapintegrity), those same entries become `<link rel="modulepreload">` tags, and extra entries become real network fetches — every page eagerly downloads every other page's private dependency graph. On an MPA with large, independent per-page graphs, measure before adopting it.
+:::
 
 ## Further Reading
 

--- a/docs/learn/coverage-strategies.md
+++ b/docs/learn/coverage-strategies.md
@@ -34,6 +34,18 @@ If your HTML already includes a `<script type="importmap">`, the plugin merges i
 
 See [import map integrity](/integrate/import-map) for CSP implications, Worker caveats, and behavior with `base: './'`.
 
+### When the map is unavailable (`importMapIntegrity: false`)
+
+Import maps must be inline, so a `script-src` without `'unsafe-inline'`, a nonce, or a matching hash blocks the map — and does so silently, since the map carries only `integrity` and nothing depends on it for resolution.
+
+The same option helps whenever the map is unavailable for *any* reason, not just CSP. A **relative `base`** also skips map injection, which leaves statically-imported sub-dependencies of lazy chunks uncovered at otherwise-default settings. The widened preload set is base-shape agnostic, so `importMapIntegrity: false` closes that gap too.
+
+Setting `importMapIntegrity: false` moves the same hashes to the other channel: no inline script is emitted, and modulepreload injection widens from "dynamically imported chunks" to the whole module graph. That matters because the widened set is what closes the gap. A chunk reached only by a static `import` inside a lazy chunk has no HTML element of its own, and there is no syntax to annotate an `import` statement with a hash — manufacturing a `<link rel="modulepreload" integrity=...>` is the only build-time way to attach one to that fetch. Neither the import map nor the `import()` rewrite is a substitute: the rewrite hooks call sites, and a static import is not a call site.
+
+This requires `preloadDynamicChunks` to stay at its default `true` — it is the channel the hashes move to. With both disabled there is no channel left for statically-imported chunks, and the build warns with a count.
+
+The cost is eager fetching. On a single-page app the increment is small, since `preloadDynamicChunks` already preloads the lazy chunks themselves; what is added is their private dependencies. On a **multi-page** build, note that the set is computed per bundle rather than per page, so each HTML file gets preload links for every module-graph chunk in the build — including chunks private to other pages. The import map always had the same bundle-wide scope, but as inert bytes rather than fetches.
+
 ## Modulepreload Injection (`preloadDynamicChunks`)
 
 **Default: enabled.**
@@ -69,6 +81,7 @@ This path activates only when **all three** of the following are true:
    - There is no HTML in the bundle (backend-owned HTML reading `manifest.json`)
    - A manifest is emitted alongside HTML (the manifest consumer's server-rendered pages have no import map)
    - `base` is relative (`'./'`, `''`, `'../…'`)
+   - `importMapIntegrity` is `false` (no map is emitted at all, so it covers nothing)
 3. `runtimePatchDynamicLinks` is `true` (required, as it installs the verifier function)
 
 In this scenario, every `import(...)` call site in the bundle is rewritten to `__sriImport(import.meta.url, ...)`. The injected `__sriImport` helper fetches the chunk, verifies its hash against the build-time integrity map using `crypto.subtle`, and only then performs the native `import()`. A hash mismatch throws and aborts module loading.
@@ -89,8 +102,12 @@ Builds that are fully covered by the import map have none of these constraints. 
 flowchart TD
     A([Build complete]) --> B{HTML emitted\nin bundle?}
     B -- no --> C[Manifest augmentation only\nno HTML-side mechanisms]
-    B -- yes --> D{base is root-relative\nor absolute URL?}
-    D -- no\nrelative base --> E[Static tag SRI ✓\nImport map: skipped\nRuntime patching active if enabled]
+    B -- yes --> IM{importMapIntegrity?}
+    IM -- false\nstrict CSP --> R{preloadDynamicChunks?}
+    R -- true\ndefault --> Q[Static tag SRI ✓\nNo inline script emitted\nModulepreload covers the\nfull module graph ✓]
+    R -- false --> S[No channel for chunks reached\nonly by a static import\nBuild warns]
+    IM -- true\ndefault --> D{base is root-relative\nor absolute URL?}
+    D -- no\nrelative base --> E[Static tag SRI ✓\nImport map: skipped\nStatic-import chunks uncovered\nBuild warns — set importMapIntegrity: false]
     D -- yes --> O{Any chunks reached\nvia the module graph?}
     O -- no\nsingle bundle, no\ncode splitting --> P[Static tag SRI ✓\nImport map: skipped\nno redundant coverage needed]
     O -- yes --> F[Static tag SRI ✓\nImport map integrity ✓]
@@ -106,7 +123,7 @@ flowchart TD
     classDef terminal fill:#16132a,stroke:#2dd4bf,color:#ccfbf1
     classDef decision fill:#16132a,stroke:#fbbf24,color:#fef3c7
     class A terminal
-    class B,D,G,I,L,O decision
+    class B,D,G,I,L,O,IM,R decision
 ```
 
 ## Comparison
@@ -114,7 +131,8 @@ flowchart TD
 | Mechanism | What it covers | Browser support | Enabled by |
 | --- | --- | --- | --- |
 | Static tag SRI | `<script>`, `<link rel="stylesheet">`, `<link rel="modulepreload">` in HTML | All SRI-supporting browsers | Always on (HTML in bundle) |
-| import map integrity | Module fetches for chunks reached via the module graph (static/dynamic import) — excludes chunks already covered by a tag's own `integrity` | Chrome 127+, Firefox 138+, Safari 18+ | HTML in bundle + root-relative/absolute `base`; skipped entirely for single-bundle builds with no code splitting |
+| import map integrity | Module fetches for chunks reached via the module graph (static/dynamic import) — excludes chunks already covered by a tag's own `integrity` | Chrome 127+, Firefox 138+, Safari 18+ | `importMapIntegrity: true` (default) + HTML in bundle + root-relative/absolute `base`; skipped entirely for single-bundle builds with no code splitting |
 | Modulepreload injection | Dynamically imported chunks (via preload + native SRI) | All SRI-supporting browsers | `preloadDynamicChunks: true` (default) |
+| Modulepreload injection, widened | The whole module graph, including chunks reached only by a static `import` inside a lazy chunk | All SRI-supporting browsers | `importMapIntegrity: false` **+** `preloadDynamicChunks: true` (default) — the strict-CSP path, replaces the import map |
 | Runtime patching | Dynamically created `<script>`/`<link>` elements | All browsers (JS-based) | `runtimePatchDynamicLinks: true` (default) |
 | JS `import()` rewriting | Dynamic `import()` call sites | All browsers with `crypto.subtle` (secure context) | Auto when `preloadDynamicChunks: false` + import map insufficient |

--- a/docs/learn/how-it-works.md
+++ b/docs/learn/how-it-works.md
@@ -43,8 +43,10 @@ flowchart TD
 **Step 3 — HTML processing.** For each `.html` asset in the bundle, the plugin performs three operations in order:
 
 - Adds `integrity` (and optionally `crossorigin`) to existing `<script>`, `<link rel="stylesheet">`, and `<link rel="modulepreload">` tags.
-- Injects `<link rel="modulepreload" integrity=...>` for each lazy chunk discovered in step 2 (when `preloadDynamicChunks` is enabled).
-- Injects or merges a `<script type="importmap">` carrying an `integrity` object for the chunks reached through the module graph — chunks already covered by a rendered tag's own `integrity` attribute are excluded, so a build with no code splitting emits no import map at all.
+- Injects `<link rel="modulepreload" integrity=...>` for each lazy chunk discovered in step 2 (when `preloadDynamicChunks` is enabled). With `importMapIntegrity: false` this set widens to the whole module graph, since it then carries every hash the import map would have. Hrefs are resolved against the document, so pages emitted into subdirectories get correct paths under a relative `base`.
+- Injects or merges a `<script type="importmap">` carrying an `integrity` object for the chunks reached through the module graph — chunks already covered by a rendered tag's own `integrity` attribute are excluded, so a build with no code splitting emits no import map at all. Skipped entirely when `importMapIntegrity` is `false`.
+
+After processing, the plugin checks every module-graph chunk against the mechanisms actually active for the build and warns about any left with no channel — naming the affected files rather than failing silently. See [Coverage Strategies](/learn/coverage-strategies).
 
 **Step 4 — Manifest augmentation.** If Vite emitted a build manifest (`build.manifest: true`), the plugin adds `integrity` and `cssIntegrity` fields to each manifest entry. This step runs even when no HTML was emitted, making it the primary path for backend-owned HTML generation.
 

--- a/docs/troubleshoot/faq.md
+++ b/docs/troubleshoot/faq.md
@@ -28,10 +28,22 @@ To add SRI to the HTML your server renders at request time, use the manifest int
 
 Import maps are necessarily inline — the HTML spec does not allow a `src` attribute on `<script type="importmap">`. A strict `Content-Security-Policy` with a `script-src` directive that excludes `'unsafe-inline'` will block the injected map.
 
-Two approaches work:
+Watch for this, because **nothing appears broken when it happens**. The injected map has no `imports` key — only `integrity` — so module resolution never depended on it and your app loads normally. What is silently lost is SRI on every chunk the map was the only cover for.
 
-- **Nonce** — your server templating injects a fresh nonce into both the `script-src` CSP header and the `<script type="importmap">` tag on every response. This is the recommended approach. The nonce changes per request, so there's nothing to update after a build.
-- **Hash** — the browser matches the inline script against a `script-src` hash value. Because the import map contains chunk content hashes, its content changes on every build. You'll need to automate hash extraction from the built HTML and CSP header updates as part of your deploy pipeline.
+The simplest fix needs no CSP cooperation at all:
+
+```ts
+sri({ importMapIntegrity: false })
+```
+
+No inline script is emitted, and the same hashes ship as `<link rel="modulepreload" integrity=...>` instead. Coverage is preserved as long as `preloadDynamicChunks` stays at its default `true` — see [`importMapIntegrity`](/configure/options#importmapintegrity) for the mechanics and the eager-fetch tradeoff.
+
+If you would rather keep the map, you must get it past `script-src` yourself:
+
+- **Nonce** — your server templating injects a fresh nonce into both the `script-src` CSP header and the `<script type="importmap">` tag on every response. The nonce changes per request, so there's nothing to update after a build.
+- **Hash** — the browser matches the inline script against a `script-src` hash value. Because the map contains chunk content hashes, its content changes on every build, so hash extraction and CSP header updates have to be automated in your deploy pipeline.
+
+To catch a gap like this the day it appears rather than months later, deploy `Integrity-Policy-Report-Only: blocked-destinations=(script)`. It reports any script fetch that carries no integrity metadata, which is exactly the failure mode a blocked import map produces.
 
 See [Import Map Integrity](/integrate/import-map) for full CSP details.
 

--- a/docs/troubleshoot/limitations.md
+++ b/docs/troubleshoot/limitations.md
@@ -37,6 +37,8 @@ See [Import Map Integrity](/integrate/import-map) for additional context on this
 
 ::: tip Broad coverage without import map integrity
 Keeping `preloadDynamicChunks: true` and `runtimePatchDynamicLinks: true` (both defaults) gives older browsers meaningful SRI coverage through modulepreload and runtime patching even without import map integrity support.
+
+For the strongest coverage on older browsers, set [`importMapIntegrity: false`](/configure/options#importmapintegrity). It moves every module-graph hash onto `<link rel="modulepreload" integrity=...>` tags, which all SRI-capable browsers enforce — so chunks that would otherwise depend on import map support, including those reached only by a static `import` inside a lazy chunk, are verified everywhere. The cost is eager fetching; see the option reference for the tradeoff.
 :::
 
 See [Import Map Integrity](/integrate/import-map) for the full browser support table and progressive-enhancement model.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2791,9 +2791,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+			"integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3431,9 +3431,9 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"version": "1.1.18",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+			"integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4363,9 +4363,9 @@
 			}
 		},
 		"node_modules/dompurify": {
-			"version": "3.4.11",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
-			"integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+			"version": "3.4.13",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+			"integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
 			"dev": true,
 			"license": "(MPL-2.0 OR Apache-2.0)",
 			"optionalDependencies": {
@@ -4920,16 +4920,16 @@
 			}
 		},
 		"node_modules/glob/node_modules/brace-expansion": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+			"integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^4.0.2"
 			},
 			"engines": {
-				"node": "18 || 20 || >=22"
+				"node": "20 || >=22"
 			}
 		},
 		"node_modules/glob/node_modules/jackspeak": {
@@ -5298,9 +5298,9 @@
 			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-			"integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+			"integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -6063,9 +6063,9 @@
 			}
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.12",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-			"integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+			"version": "3.3.17",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+			"integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
 			"dev": true,
 			"funding": [
 				{
@@ -6349,9 +6349,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.15",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-			"integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+			"version": "8.5.25",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+			"integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
 			"dev": true,
 			"funding": [
 				{
@@ -6369,7 +6369,7 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"nanoid": "^3.3.12",
+				"nanoid": "^3.3.16",
 				"picocolors": "^1.1.1",
 				"source-map-js": "^1.2.1"
 			},
@@ -6976,9 +6976,9 @@
 			}
 		},
 		"node_modules/sucrase/node_modules/brace-expansion": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+			"integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7071,9 +7071,9 @@
 			}
 		},
 		"node_modules/test-exclude/node_modules/brace-expansion": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+			"integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ type NormalizedOutputOptions = Rollup.NormalizedOutputOptions;
 type OutputBundle = Rollup.OutputBundle;
 import type { BundleLogger } from "./internal";
 import {
+	collectModuleChunkFiles,
 	createLogger,
 	DynamicImportAnalyzer,
 	escapeForScript,
@@ -35,6 +36,32 @@ export interface SriPluginOptions {
 	fetchTimeoutMs?: number;
 	/** Add rel="modulepreload" with integrity for discovered dynamic chunks. Default: true */
 	preloadDynamicChunks?: boolean;
+	/**
+	 * Deliver module-graph integrity via an inline `<script type="importmap">`.
+	 * Default: true.
+	 *
+	 * Import maps must be inline — the HTML spec forbids `src` on
+	 * `<script type="importmap">` — so a `script-src` without `'unsafe-inline'`,
+	 * a matching hash, or a nonce will block the map. A blocked map delivers no
+	 * integrity, silently.
+	 *
+	 * Set to false for strict-CSP deployments: no inline script is emitted, and
+	 * the same hashes are delivered as `<link rel="modulepreload" integrity>`
+	 * instead, which needs no CSP cooperation. Coverage is preserved — the
+	 * preload set widens to the full module graph so chunks reached only by a
+	 * static import inside a lazy chunk stay verified. Those chunks are then
+	 * fetched eagerly rather than on demand.
+	 *
+	 * Requires `preloadDynamicChunks` (the default) to remain enabled — that is
+	 * the channel the hashes move to. With both off, chunks reached only by a
+	 * static import inside a lazy chunk have no channel at all and the build
+	 * warns.
+	 *
+	 * The widened set is bundle-wide, not per page, so in a multi-page build
+	 * every HTML file preloads every module-graph chunk, including chunks
+	 * private to other pages.
+	 */
+	importMapIntegrity?: boolean;
 	/** Inject a tiny runtime that sets integrity on dynamically inserted <script>/<link>. Default: true */
 	runtimePatchDynamicLinks?: boolean;
 	/** Skip SRI generation for resources matching these patterns. Supports exact matches and simple glob patterns with '*'. */
@@ -153,6 +180,7 @@ export default function sri(options: SriPluginOptions = {}): PluginOption {
 		: undefined;
 	let isSSR = false;
 	const preloadDynamicChunks = options.preloadDynamicChunks !== false; // default true
+	const importMapIntegrity = options.importMapIntegrity !== false; // default true
 	const runtimePatchDynamicLinks = options.runtimePatchDynamicLinks !== false; // default true
 	const skipResources = options.skipResources ?? []; // default empty array
 	const verboseLogging = options.verboseLogging === true; // default false
@@ -272,6 +300,23 @@ export default function sri(options: SriPluginOptions = {}): PluginOption {
 					//   2) Inject runtime into entry chunks
 					//   3) Hash entry chunks (now includes the injected runtime)
 					// - When disabled, we can hash everything in a single pass for efficiency
+
+					// Whether the import map can cover every consumer of this
+					// bundle. It cannot when there is no HTML in the bundle
+					// (backend-owned HTML / manifest consumers), when a manifest
+					// is emitted ALONGSIDE HTML (the manifest consumer's
+					// server-rendered pages have no import map), when base is
+					// relative (no valid import map keys), or when the user
+					// disabled the inline-script channel outright (strict CSP),
+					// in which case no map is emitted at all.
+					const importMapCapable =
+						importMapIntegrity &&
+						hasHtmlFiles &&
+						!hasManifestFiles &&
+						isImportMapCapableBase(base);
+					const enforceDynamicImports =
+						!preloadDynamicChunks && !importMapCapable;
+
 					if (runtimePatchDynamicLinks) {
 						// Step 2a-pre: Rewrite dynamic import() call sites when
 						// JS-level enforcement is active. This is performed BEFORE
@@ -279,23 +324,10 @@ export default function sri(options: SriPluginOptions = {}): PluginOption {
 						// Activation condition: the user has disabled the
 						// build-time modulepreload injection (preloadDynamicChunks
 						// is false) AND the import map cannot cover every consumer
-						// of this bundle. JS-level enforcement is the fallback
-						// for builds where the import map is insufficient: no
-						// HTML in the bundle (backend-owned HTML / manifest
-						// consumers), a manifest emitted ALONGSIDE HTML (the
-						// manifest consumer's server-rendered pages have no
-						// import map, so suppressing the rewrite would silently
-						// drop their enforcement), or a relative base (no valid
-						// import map keys). Wherever the import map covers all
-						// consumers it subsumes this path — the browser enforces
-						// SRI natively on module fetches (single fetch, no
-						// rewrite, source maps kept).
-						const importMapCapable =
-							hasHtmlFiles &&
-							!hasManifestFiles &&
-							isImportMapCapableBase(base);
-						const enforceDynamicImports =
-							!preloadDynamicChunks && !importMapCapable;
+						// of this bundle (see importMapCapable above). Wherever
+						// the import map covers all consumers it subsumes this
+						// path — the browser enforces SRI natively on module
+						// fetches (single fetch, no rewrite, source maps kept).
 						if (enforceDynamicImports) {
 							// ORDERING INVARIANT: this rewrite MUST run before
 							// any hashing AND before the runtime is injected
@@ -397,11 +429,62 @@ export default function sri(options: SriPluginOptions = {}): PluginOption {
 							dynamicImportAnalyzer.redundantImportMapChunks(
 								bundle
 							);
+
+						// Never degrade coverage silently. Model every channel
+						// explicitly and warn about whatever none of them reach,
+						// rather than inferring it from one flag pair — the
+						// earlier flag-based guard missed the case this exists to
+						// catch (relative base at stock defaults: no map, narrow
+						// preloads, no rewrite, and no warning).
+						//
+						// A module-graph chunk is covered when:
+						//  - the import map is emitted (covers every chunk), or
+						//  - modulepreload injection reaches it: the whole graph
+						//    when widened, otherwise only dynamic import targets,
+						//    or
+						//  - the import() rewrite is active AND it is a dynamic
+						//    import target. The rewrite hooks call sites, so it
+						//    can never reach a chunk pulled by a STATIC import
+						//    inside a lazy chunk.
+						//
+						// Gated on chunks actually existing, so a single-bundle
+						// build with no module-graph fetches stays quiet.
+						const moduleChunks = collectModuleChunkFiles(
+							sriByPathname,
+							skipResources,
+							redundantImportMapChunks
+						).map((f) => f.fileName);
+						const covered = new Set<string>();
+						if (importMapCapable) {
+							moduleChunks.forEach((f) => covered.add(f));
+						}
+						if (preloadDynamicChunks) {
+							if (!importMapIntegrity) {
+								moduleChunks.forEach((f) => covered.add(f));
+							} else {
+								dynamicChunkFiles.forEach((f) => covered.add(f));
+							}
+						}
+						if (enforceDynamicImports && runtimePatchDynamicLinks) {
+							dynamicChunkFiles.forEach((f) => covered.add(f));
+						}
+						const uncovered = moduleChunks.filter(
+							(f) => !covered.has(f)
+						);
+						if (uncovered.length > 0) {
+							logger.warn(
+								`${uncovered.length} module-graph chunk(s) will load without SRI — no active mechanism covers them. ` +
+									"Set importMapIntegrity: false to cover them with modulepreload links (requires preloadDynamicChunks). " +
+									`Affected: ${uncovered.slice(0, 5).join(", ")}${uncovered.length > 5 ? `, +${uncovered.length - 5} more` : ""}`
+							);
+						}
+
 						const htmlProcessor = new HtmlProcessor({
 							algorithm,
 							crossorigin,
 							base,
 							preloadDynamicChunks,
+							importMapIntegrity,
 							enableCache,
 							remoteCache,
 							pending,

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -72,6 +72,13 @@ export interface HtmlProcessorConfig {
 	base: string;
 	/** Whether to inject modulepreload links for dynamic chunks */
 	preloadDynamicChunks: boolean;
+	/**
+	 * Whether to deliver module-graph integrity via an inline
+	 * `<script type="importmap">`. When false, no inline script is emitted and
+	 * the same hashes are delivered as `<link rel="modulepreload" integrity>`
+	 * instead. Defaults to true when omitted.
+	 */
+	importMapIntegrity?: boolean;
 	/** Whether to enable HTTP caching for remote resources */
 	enableCache: boolean;
 	/** HTTP cache storage for remote resource bytes */
@@ -178,6 +185,45 @@ export function joinBaseHref(base: string, chunkFile: string): string {
 }
 
 /**
+ * The href to use for an injected `<link rel="modulepreload">` in a specific
+ * HTML document.
+ *
+ * Absolute and root-relative bases are document-independent, so joinBaseHref
+ * is exact. A RELATIVE base is not: the browser resolves the href against the
+ * document's own URL, so an HTML file emitted into a subdirectory needs a
+ * different string than one at the output root. joinBaseHref is a pure
+ * function of (base, chunkFile) and would emit an identical href for every
+ * page — correct only at the root, and silently wrong everywhere else. A
+ * mismatched preload URL never matches the loader's real fetch, so SRI is not
+ * enforced and a bogus request is issued.
+ *
+ * Both `chunkFile` and `htmlFileName` are bundle-relative, so for a relative
+ * base the answer is simply the path from the document's directory to the
+ * chunk — which is what Vite itself emits for its own tags.
+ *
+ * @example
+ * preloadHref("./", "assets/dep.js", "admin/index.html")
+ * // "../assets/dep.js"
+ *
+ * preloadHref("./", "assets/dep.js", "index.html")
+ * // "./assets/dep.js"
+ */
+export function preloadHref(
+	base: string,
+	chunkFile: string,
+	htmlFileName: string
+): string {
+	if (isHttpUrl(base) || base.startsWith("/")) {
+		return joinBaseHref(base, chunkFile);
+	}
+	const dir = path.posix.dirname(htmlFileName);
+	const rel = path.posix.relative(dir === "" ? "." : dir, chunkFile);
+	// Match Vite's own "./"-prefixed style so duplicate detection against the
+	// links Vite already emitted compares equal.
+	return rel.startsWith("..") ? rel : `./${rel}`;
+}
+
+/**
  * Whether the resolved Vite `base` can produce valid import map `integrity`
  * keys. Import map keys must be URL-like — root-relative (`/...`),
  * `./`/`../`-relative, or absolute URLs. The plugin only emits root-relative
@@ -208,15 +254,46 @@ export function buildImportIntegrityObject(
 ): Record<string, string> | null {
 	if (!isImportMapCapableBase(base)) return null;
 	const result: Record<string, string> = {};
-	for (const [pathname, integrity] of Object.entries(sriByPathname)) {
+	for (const { pathname, fileName } of collectModuleChunkFiles(
+		sriByPathname,
+		skipResources,
+		excludeFileNames
+	)) {
+		result[joinBaseHref(base, fileName)] = sriByPathname[pathname];
+	}
+	return result;
+}
+
+/**
+ * The set of emitted JS module chunks that need integrity delivered through a
+ * module-graph channel — i.e. every hashed .js/.mjs asset except those the user
+ * opted out of via `skipResources` and those already protected by an
+ * integrity-bearing <script>/<link> tag (excludeFileNames).
+ *
+ * This is the single source of truth for module-graph coverage. Both delivery
+ * channels consume it: the inline import map (buildImportIntegrityObject) and
+ * modulepreload injection when the import map is disabled. Keeping one
+ * definition is what makes the channels interchangeable without leaving gaps.
+ *
+ * Unlike buildImportIntegrityObject this does not require an import-map-capable
+ * base: modulepreload hrefs resolve against the document URL, so a relative
+ * `base` that cannot produce valid import map keys still produces valid links.
+ */
+export function collectModuleChunkFiles(
+	sriByPathname: Record<string, string>,
+	skipResources: string[] = [],
+	excludeFileNames: Set<string> = new Set()
+): Array<{ pathname: string; fileName: string }> {
+	const files: Array<{ pathname: string; fileName: string }> = [];
+	for (const pathname of Object.keys(sriByPathname)) {
 		// Match PROCESSABLE_EXTENSIONS semantics: allow a query suffix.
 		if (!/\.m?js(\?|$)/i.test(pathname)) continue;
 		const fileName = pathname.startsWith("/") ? pathname.slice(1) : pathname;
 		if (isSkippedResource(fileName, skipResources)) continue;
 		if (excludeFileNames.has(fileName)) continue;
-		result[joinBaseHref(base, fileName)] = integrity;
+		files.push({ pathname, fileName });
 	}
-	return result;
+	return files;
 }
 
 /**
@@ -1794,12 +1871,34 @@ export class HtmlProcessor {
 		// DYNAMIC CHUNK PRELOAD INJECTION
 		// ========================================================================
 
-		// Step 2: Add preload links for dynamic chunks (if enabled)
-		if (this.config.preloadDynamicChunks && dynamicChunkFiles.size > 0) {
+		// Step 2: Add preload links for dynamic chunks (if enabled).
+		//
+		// With the import map disabled there is no inline-script channel, so the
+		// preload set widens from "dynamically imported chunks" to the whole
+		// module graph. That closes the one gap the map used to cover alone:
+		// chunks reached only by a static `import` inside a lazy chunk, which
+		// have no HTML element of their own and cannot be annotated at the
+		// import site (there is no syntax for it). Manufacturing a
+		// <link rel="modulepreload" integrity> is the only build-time way to
+		// attach a hash to that fetch. Cost: those chunks are fetched eagerly.
+		const preloadFiles =
+			this.config.importMapIntegrity === false
+				? new Set([
+					...dynamicChunkFiles,
+					...collectModuleChunkFiles(
+						sriByPathname,
+						this.config.skipResources,
+						redundantImportMapChunks
+					).map((f) => f.fileName),
+				])
+				: dynamicChunkFiles;
+
+		if (this.config.preloadDynamicChunks && preloadFiles.size > 0) {
 			processedHtml = await this.addDynamicChunkPreloads(
 				processedHtml,
-				dynamicChunkFiles,
-				sriByPathname
+				preloadFiles,
+				sriByPathname,
+				fileName
 			);
 		}
 
@@ -1808,13 +1907,18 @@ export class HtmlProcessor {
 		// ========================================================================
 
 		// Step 3: Inject import map integrity (runs after preload injection so
-		// the unshift places the map BEFORE the modulepreload links).
-		processedHtml = this.injectImportMap(
-			processedHtml,
-			sriByPathname,
-			fileName,
-			redundantImportMapChunks
-		);
+		// the unshift places the map BEFORE the modulepreload links). Skipped
+		// entirely when the inline-script channel is disabled — a strict CSP
+		// without 'unsafe-inline' blocks the map, and a blocked map silently
+		// delivers no integrity at all.
+		if (this.config.importMapIntegrity !== false) {
+			processedHtml = this.injectImportMap(
+				processedHtml,
+				sriByPathname,
+				fileName,
+				redundantImportMapChunks
+			);
+		}
 
 		// ========================================================================
 		// BUNDLE UPDATE
@@ -1907,7 +2011,8 @@ export class HtmlProcessor {
 	private async addDynamicChunkPreloads(
 		htmlContent: string,
 		dynamicChunkFiles: Set<string>,
-		sriByPathname: Record<string, string>
+		sriByPathname: Record<string, string>,
+		htmlFileName: string
 	): Promise<string> {
 		try {
 			// ====================================================================
@@ -1940,7 +2045,12 @@ export class HtmlProcessor {
 			// Process each dynamic chunk file
 			for (const chunkFile of dynamicChunkFiles) {
 				if (
-					this.addPreloadLinkForChunk(head, chunkFile, sriByPathname)
+					this.addPreloadLinkForChunk(
+						head,
+						chunkFile,
+						sriByPathname,
+						htmlFileName
+					)
 				) {
 					addedCount++;
 				}
@@ -1989,14 +2099,17 @@ export class HtmlProcessor {
 	private addPreloadLinkForChunk(
 		head: Element,
 		chunkFile: string,
-		sriByPathname: Record<string, string>
+		sriByPathname: Record<string, string>,
+		htmlFileName: string
 	): boolean {
 		// ========================================================================
 		// HREF GENERATION AND DUPLICATE CHECKING
 		// ========================================================================
 
-		// Build absolute href using base path
-		const href = joinBaseHref(this.config.base, chunkFile);
+		// Build the href for THIS document — a relative base resolves against
+		// the document's own URL, so a page in a subdirectory needs a different
+		// string than one at the output root.
+		const href = preloadHref(this.config.base, chunkFile, htmlFileName);
 
 		// Check if preload link already exists (duplicate prevention)
 		const existingPreloads = findElements(head, (el) => {
@@ -2012,6 +2125,16 @@ export class HtmlProcessor {
 		// ========================================================================
 		// INTEGRITY VALIDATION
 		// ========================================================================
+
+		// Honour the user's opt-out. collectModuleChunkFiles already filters the
+		// widened set, but dynamicChunkFiles comes straight from the chunk graph
+		// and has no skipResources awareness — without this check a skipped
+		// chunk that happens to be a dynamic import target would still be
+		// preloaded with an integrity attribute, silently overriding an explicit
+		// exclusion that the import map channel honours.
+		if (isSkippedResource(chunkFile, this.config.skipResources)) {
+			return false;
+		}
 
 		// Get integrity for this chunk
 		const integrity = sriByPathname[path.posix.join("/", chunkFile)];

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -3096,3 +3096,430 @@ describe("import map SRI", () => {
 		expect(mapIdx).toBeLessThan(titleIdx);
 	});
 });
+
+describe("importMapIntegrity: CSP-safe coverage without an inline script", () => {
+	// Reproduces the reported topology: a lazy route chunk reached by import(),
+	// which in turn statically imports a leaf chunk. The leaf has no HTML
+	// element of its own, so today only the import map covers it.
+	function makeGapBundle(): Record<string, Chunk | Asset> {
+		return {
+			"index.html": {
+				type: "asset",
+				source:
+					'<!doctype html><html><head><script type="module" src="/assets/entry.js"></script></head><body></body></html>',
+			},
+			"assets/entry.js": makeEntryChunk({
+				code: "const p = import('./lazy.js'); console.log(p);",
+				dynamicImports: ["src/lazy.ts"],
+			}),
+			"assets/lazy.js": {
+				type: "chunk",
+				fileName: "assets/lazy.js",
+				code: "import './dep.js'; export default 1",
+				imports: ["src/dep.ts"],
+				dynamicImports: [],
+				modules: { "src/lazy.ts": {} },
+				name: "lazy",
+				facadeModuleId: "src/lazy.ts",
+			},
+			"assets/dep.js": {
+				type: "chunk",
+				fileName: "assets/dep.js",
+				code: "export const dep = 42",
+				imports: [],
+				dynamicImports: [],
+				modules: { "src/dep.ts": {} },
+				name: "dep",
+				facadeModuleId: "src/dep.ts",
+			},
+		} as any;
+	}
+
+	it("covers statically-imported lazy dependencies with a modulepreload link", async () => {
+		const plugin = sri({
+			algorithm: "sha256",
+			importMapIntegrity: false,
+		}) as any;
+		plugin.configResolved?.({ base: "/", build: { ssr: false } } as any);
+
+		const bundle = makeGapBundle();
+		await plugin.generateBundle.handler({}, bundle as any);
+		const html = String((bundle["index.html"] as Asset).source);
+
+		expect(html).toMatch(
+			/<link rel="modulepreload" href="\/assets\/dep\.js" integrity="sha256-[^"]+"/
+		);
+	});
+
+	it("emits no inline import map script when disabled", async () => {
+		const plugin = sri({
+			algorithm: "sha256",
+			importMapIntegrity: false,
+		}) as any;
+		plugin.configResolved?.({ base: "/", build: { ssr: false } } as any);
+
+		const bundle = makeGapBundle();
+		await plugin.generateBundle.handler({}, bundle as any);
+		const html = String((bundle["index.html"] as Asset).source);
+
+		expect(html).not.toContain("importmap");
+	});
+
+	it("keeps the import map and narrow preloads when left at its default", async () => {
+		const plugin = sri({ algorithm: "sha256" }) as any;
+		plugin.configResolved?.({ base: "/", build: { ssr: false } } as any);
+
+		const bundle = makeGapBundle();
+		await plugin.generateBundle.handler({}, bundle as any);
+		const html = String((bundle["index.html"] as Asset).source);
+
+		expect(html).toContain('type="importmap"');
+		expect(html).toContain("/assets/dep.js");
+		// Regression guard: the default must not start eagerly preloading leaves.
+		expect(html).not.toMatch(
+			/<link rel="modulepreload" href="\/assets\/dep\.js"/
+		);
+	});
+
+	it("makes JS-level import() enforcement reachable once the map is off", async () => {
+		const plugin = sri({
+			algorithm: "sha256",
+			importMapIntegrity: false,
+			preloadDynamicChunks: false,
+		}) as any;
+		plugin.configResolved?.({ base: "/", build: { ssr: false } } as any);
+
+		const bundle = makeGapBundle();
+		await plugin.generateBundle.handler({}, bundle as any);
+
+		const entryCode = (bundle["assets/entry.js"] as Chunk).code;
+		expect(entryCode).toContain("enforceDynamicImports: true");
+		expect(entryCode).toContain("__sriImport(import.meta.url, './lazy.js')");
+	});
+
+	it("does not warn once the widened preload set already covers the graph", async () => {
+		// preloadDynamicChunks left at its default (true)
+		const plugin = sri({
+			algorithm: "sha256",
+			importMapIntegrity: false,
+		}) as any;
+		plugin.configResolved?.({ base: "/", build: { ssr: false } } as any);
+
+		const mockContext = createMockPluginContext();
+		await plugin.generateBundle.handler.call(
+			mockContext,
+			{},
+			makeGapBundle() as any
+		);
+
+		expect(mockContext.warn).not.toHaveBeenCalledWith(
+			expect.stringContaining("will load without SRI")
+		);
+	});
+
+	it("counts only chunks the import() rewrite cannot reach", async () => {
+		// entry -> import() -> lazy.js -> static import -> dep.js
+		// The rewrite covers lazy.js, so only dep.js is genuinely unverified.
+		const plugin = sri({
+			algorithm: "sha256",
+			importMapIntegrity: false,
+			preloadDynamicChunks: false,
+		}) as any;
+		plugin.configResolved?.({ base: "/", build: { ssr: false } } as any);
+
+		const mockContext = createMockPluginContext();
+		await plugin.generateBundle.handler.call(
+			mockContext,
+			{},
+			makeGapBundle() as any
+		);
+
+		expect(mockContext.warn).toHaveBeenCalledWith(
+			expect.stringContaining("1 module-graph chunk(s)")
+		);
+	});
+
+	it("counts dynamic chunks too when the rewrite is disabled", async () => {
+		const plugin = sri({
+			algorithm: "sha256",
+			importMapIntegrity: false,
+			preloadDynamicChunks: false,
+			runtimePatchDynamicLinks: false,
+		}) as any;
+		plugin.configResolved?.({ base: "/", build: { ssr: false } } as any);
+
+		const mockContext = createMockPluginContext();
+		await plugin.generateBundle.handler.call(
+			mockContext,
+			{},
+			makeGapBundle() as any
+		);
+
+		expect(mockContext.warn).toHaveBeenCalledWith(
+			expect.stringContaining("2 module-graph chunk(s)")
+		);
+	});
+
+	it("warns when no channel is left to carry module-graph integrity", async () => {
+		const plugin = sri({
+			algorithm: "sha256",
+			importMapIntegrity: false,
+			preloadDynamicChunks: false,
+		}) as any;
+		plugin.configResolved?.({ base: "/", build: { ssr: false } } as any);
+
+		const mockContext = createMockPluginContext();
+		await plugin.generateBundle.handler.call(
+			mockContext,
+			{},
+			makeGapBundle() as any
+		);
+
+		expect(mockContext.warn).toHaveBeenCalledWith(
+			expect.stringContaining("will load without SRI")
+		);
+	});
+
+	it("propagates crossorigin onto widened preload links", async () => {
+		// SRI on a cross-origin fetch requires CORS, so the attribute must
+		// reach the links added by the widened set, not just the narrow one.
+		const plugin = sri({
+			algorithm: "sha256",
+			importMapIntegrity: false,
+			crossorigin: "anonymous",
+		}) as any;
+		plugin.configResolved?.({ base: "/", build: { ssr: false } } as any);
+
+		const bundle = makeGapBundle();
+		await plugin.generateBundle.handler({}, bundle as any);
+		const html = String((bundle["index.html"] as Asset).source);
+
+		expect(html).toMatch(
+			/<link rel="modulepreload" href="\/assets\/dep\.js" integrity="sha256-[^"]+" crossorigin="anonymous">/
+		);
+	});
+
+	it("keeps skipResources opt-outs out of the widened preload set", async () => {
+		const plugin = sri({
+			algorithm: "sha256",
+			importMapIntegrity: false,
+			skipResources: ["**/dep.js"],
+		}) as any;
+		plugin.configResolved?.({ base: "/", build: { ssr: false } } as any);
+
+		const bundle = makeGapBundle();
+		await plugin.generateBundle.handler({}, bundle as any);
+		const html = String((bundle["index.html"] as Asset).source);
+
+		expect(html).not.toContain("/assets/dep.js");
+	});
+});
+
+describe("no-channel warning", () => {
+	it("stays quiet for a single-bundle build with no module-graph chunks", async () => {
+		const plugin = sri({
+			algorithm: "sha256",
+			importMapIntegrity: false,
+			preloadDynamicChunks: false,
+		}) as any;
+		plugin.configResolved?.({ base: "/", build: { ssr: false } } as any);
+
+		const mockContext = createMockPluginContext();
+		const bundle: any = {
+			"index.html": {
+				type: "asset",
+				source:
+					'<!doctype html><html><head><script type="module" src="/assets/entry.js"></script></head><body></body></html>',
+			},
+			"assets/entry.js": makeEntryChunk({ code: "console.log('only')" }),
+		};
+
+		await plugin.generateBundle.handler.call(mockContext, {}, bundle);
+
+		expect(mockContext.warn).not.toHaveBeenCalledWith(
+			expect.stringContaining("will load without SRI")
+		);
+	});
+});
+
+describe("relative base preload hrefs resolve against the document", () => {
+	function nestedBundle(): any {
+		return {
+			"index.html": {
+				type: "asset",
+				source:
+					'<!doctype html><html><head><script type="module" src="./assets/entry.js"></script></head><body></body></html>',
+			},
+			"admin/index.html": {
+				type: "asset",
+				source:
+					'<!doctype html><html><head><script type="module" src="../assets/entry.js"></script></head><body></body></html>',
+			},
+			"assets/entry.js": {
+				type: "chunk",
+				fileName: "assets/entry.js",
+				code: "import './dep.js'; console.log(1)",
+				imports: ["src/dep.ts"],
+				dynamicImports: [],
+				modules: { "src/entry.ts": {} },
+				name: "entry",
+				isEntry: true,
+				facadeModuleId: "src/entry.ts",
+			},
+			"assets/dep.js": {
+				type: "chunk",
+				fileName: "assets/dep.js",
+				code: "export const d = 1",
+				imports: [],
+				dynamicImports: [],
+				modules: { "src/dep.ts": {} },
+				name: "dep",
+				facadeModuleId: "src/dep.ts",
+			},
+		};
+	}
+
+	it("prefixes ../ for HTML emitted into a subdirectory", async () => {
+		const plugin = sri({
+			algorithm: "sha256",
+			importMapIntegrity: false,
+		}) as any;
+		plugin.configResolved?.({ base: "./", build: { ssr: false } } as any);
+
+		const bundle = nestedBundle();
+		await plugin.generateBundle.handler({}, bundle);
+
+		expect(String(bundle["admin/index.html"].source)).toMatch(
+			/<link rel="modulepreload" href="\.\.\/assets\/dep\.js" integrity="sha256-/
+		);
+	});
+
+	it("keeps root-level HTML pointing at its own directory", async () => {
+		const plugin = sri({
+			algorithm: "sha256",
+			importMapIntegrity: false,
+		}) as any;
+		plugin.configResolved?.({ base: "./", build: { ssr: false } } as any);
+
+		const bundle = nestedBundle();
+		await plugin.generateBundle.handler({}, bundle);
+
+		expect(String(bundle["index.html"].source)).toMatch(
+			/<link rel="modulepreload" href="\.\/assets\/dep\.js" integrity="sha256-/
+		);
+	});
+
+	it("leaves root-relative and absolute bases document-independent", async () => {
+		for (const base of ["/", "https://cdn.example.com/"]) {
+			const plugin = sri({
+				algorithm: "sha256",
+				importMapIntegrity: false,
+			}) as any;
+			plugin.configResolved?.({ base, build: { ssr: false } } as any);
+
+			const bundle = nestedBundle();
+			await plugin.generateBundle.handler({}, bundle);
+
+			const expected = `href="${base === "/" ? "/assets/dep.js" : "https://cdn.example.com/assets/dep.js"}"`;
+			expect(String(bundle["index.html"].source)).toContain(expected);
+			expect(String(bundle["admin/index.html"].source)).toContain(expected);
+		}
+	});
+});
+
+describe("silent-gap detection at stock defaults", () => {
+	function relativeBaseGraph(): any {
+		return {
+			"index.html": {
+				type: "asset",
+				source:
+					'<!doctype html><html><head><script type="module" src="./assets/entry.js"></script></head><body></body></html>',
+			},
+			"assets/entry.js": {
+				type: "chunk",
+				fileName: "assets/entry.js",
+				code: "import('./lazy.js')",
+				imports: [],
+				dynamicImports: ["src/lazy.ts"],
+				modules: { "src/entry.ts": {} },
+				name: "entry",
+				isEntry: true,
+				facadeModuleId: "src/entry.ts",
+			},
+			"assets/lazy.js": {
+				type: "chunk",
+				fileName: "assets/lazy.js",
+				code: "import './dep.js'; export const l = 1",
+				imports: ["src/dep.ts"],
+				dynamicImports: [],
+				modules: { "src/lazy.ts": {} },
+				name: "lazy",
+				facadeModuleId: "src/lazy.ts",
+			},
+			"assets/dep.js": {
+				type: "chunk",
+				fileName: "assets/dep.js",
+				code: "export const d = 1",
+				imports: [],
+				dynamicImports: [],
+				modules: { "src/dep.ts": {} },
+				name: "dep",
+				facadeModuleId: "src/dep.ts",
+			},
+		};
+	}
+
+	it("warns about a relative-base gap even with every option untouched", async () => {
+		// No import map (relative base), narrow preloads only, no rewrite —
+		// dep.js reaches the browser unverified and used to do so in silence.
+		const plugin = sri({ algorithm: "sha256" }) as any;
+		plugin.configResolved?.({ base: "./", build: { ssr: false } } as any);
+
+		const mockContext = createMockPluginContext();
+		await plugin.generateBundle.handler.call(
+			mockContext,
+			{},
+			relativeBaseGraph()
+		);
+
+		expect(mockContext.warn).toHaveBeenCalledWith(
+			expect.stringContaining("assets/dep.js")
+		);
+	});
+
+	it("goes quiet on a relative-base build once the widened set is enabled", async () => {
+		const plugin = sri({
+			algorithm: "sha256",
+			importMapIntegrity: false,
+		}) as any;
+		plugin.configResolved?.({ base: "./", build: { ssr: false } } as any);
+
+		const mockContext = createMockPluginContext();
+		const bundle = relativeBaseGraph();
+		await plugin.generateBundle.handler.call(mockContext, {}, bundle);
+
+		expect(mockContext.warn).not.toHaveBeenCalledWith(
+			expect.stringContaining("will load without SRI")
+		);
+		expect(String(bundle["index.html"].source)).toContain(
+			'href="./assets/dep.js"'
+		);
+	});
+
+	it("drops a skipResources chunk from preloads even when dynamically imported", async () => {
+		const plugin = sri({
+			algorithm: "sha256",
+			skipResources: ["**/lazy.js"],
+		}) as any;
+		plugin.configResolved?.({ base: "/", build: { ssr: false } } as any);
+
+		const bundle = relativeBaseGraph();
+		bundle["index.html"].source =
+			'<!doctype html><html><head><script type="module" src="/assets/entry.js"></script></head><body></body></html>';
+		await plugin.generateBundle.handler({}, bundle);
+
+		expect(String(bundle["index.html"].source)).not.toContain(
+			'href="/assets/lazy.js"'
+		);
+	});
+});

--- a/test/internal.spec.ts
+++ b/test/internal.spec.ts
@@ -18,6 +18,7 @@ import {
 	isHttpUrl,
 	isImportMapCapableBase,
 	buildImportIntegrityObject,
+	collectModuleChunkFiles,
 	joinBaseHref,
 	loadResource,
 	ManifestProcessor,
@@ -5984,5 +5985,34 @@ describe("Coverage Gap Closures", () => {
 				/no integrity registered for \.\/asset\.js \(resolved to https:\/\/app\.test\/assets\/js\/asset\.js\)/i
 			);
 		});
+	});
+});
+
+describe("collectModuleChunkFiles", () => {
+	const sriByPathname = {
+		"/assets/dep.js": "sha256-dep",
+		"/assets/app.mjs": "sha256-app",
+		"/assets/style.css": "sha256-css",
+	};
+
+	it("returns only JS module chunks", () => {
+		const files = collectModuleChunkFiles(sriByPathname).map((f) => f.fileName);
+		expect(files).toEqual(["assets/dep.js", "assets/app.mjs"]);
+	});
+
+	it("honours skipResources and tag-covered exclusions", () => {
+		const files = collectModuleChunkFiles(
+			sriByPathname,
+			["**/dep.js"],
+			new Set(["assets/app.mjs"])
+		);
+		expect(files).toEqual([]);
+	});
+
+	it("still yields chunks for a relative base that cannot produce import map keys", () => {
+		// modulepreload hrefs resolve against the document URL, so a relative
+		// base is usable here even though it yields no valid import map.
+		expect(buildImportIntegrityObject(sriByPathname, "./")).toBeNull();
+		expect(collectModuleChunkFiles(sriByPathname).length).toBe(2);
 	});
 });


### PR DESCRIPTION
## Problem

The inline `<script type="importmap">` the plugin injects is itself a violation of a strict `Content-Security-Policy` — one whose `script-src` omits `'unsafe-inline'`. Chrome enforces `script-src` on import maps even though they don't execute code, so `'self'` alone blocks it.

**Nothing appears broken when this happens.** The injected map has no `imports` key, only `integrity`, so module resolution never depended on it and the app loads normally. What is silently lost is SRI on every chunk the map alone covered.

This is not fixable by tightening the map. Import maps must be inline — the HTML spec forbids `src` on `<script type="importmap">`, and external import maps have never shipped in any browser (the WICG issue tracking them was archived in Feb 2025, still in the "Future" milestone). A build-time plugin also cannot write your server's CSP header. So the map is either permitted by the policy or it delivers nothing.

The affected chunks are specifically those reached by a **static `import` inside a lazily-imported chunk**. They have no HTML element of their own, and there is no syntax to annotate an `import` statement with a hash — which is the entire reason import map integrity was specced. The existing JS `import()` rewrite is not a fallback for them either: it hooks call sites, and a static import is not a call site.

## Change

Adds `importMapIntegrity` (default `true`, so existing builds are unchanged). Set it to `false` and no inline script is emitted; the same hashes ship as `<link rel="modulepreload" integrity>`, which `script-src` does not govern and which needs no server coordination.

Coverage is preserved rather than reduced. With the map disabled, modulepreload injection widens from "dynamically imported chunks" to the whole module graph, so those static-import chunks stay verified. Both channels now select from a single `collectModuleChunkFiles` helper — that shared definition is what makes them interchangeable without gaps.

Verified against the HTML spec: the document module map is keyed only on `(url, moduleType)`, with integrity stored in the entry's fetch options rather than the key. A `modulepreload` stores its result in that same map, so a later import of that URL reuses the already-verified entry, and a failed check stores a null entry and fails closed. The preload link is injected at the start of `<head>`, ahead of any script, so it always wins the race to populate the map.

## Pre-existing defects found while reviewing the above

- **Modulepreload hrefs ignored the document.** `joinBaseHref(base, chunkFile)` is a pure function of base and chunk, so under a relative `base` every page received an identical href — correct only at the output root. A page emitted to `admin/index.html` got `assets/x.js` where it needed `../assets/x.js`, producing a 404 that enforced nothing, while Vite's own tag on that page was correct. Affected the default dynamic-chunk path, not just the new one.

- **`skipResources` was bypassed for dynamic import targets.** The widened set filtered correctly, but it unions with `dynamicChunkFiles`, which comes from the chunk graph with no opt-out awareness. A skip-listed chunk that happened to be a dynamic import target was still preloaded with an integrity attribute — the map channel honoured the exclusion while the preload channel overrode it.

- **The coverage warning never fired at default settings.** It inferred coverage from a flag pair instead of modelling the channels. A relative `base` (or a manifest emitted alongside HTML) left statically-imported sub-dependencies of lazy chunks unverified with **no signal at any log level** — `info` is a no-op unless `verboseLogging` is set. The check now builds a covered-set from each active mechanism and reports whatever none of them reach, naming the files.

## Tradeoffs

Eager fetching: the widened set is downloaded when the HTML is parsed rather than when the lazy route needs it. On an SPA the increment is small, since `preloadDynamicChunks` already preloads the lazy chunks themselves — what's added is their private dependencies.

On an **MPA** the set is bundle-wide rather than per-page, so every HTML file gets links for chunks private to other pages. The import map always had that same scope, but as inert inline bytes rather than fetches. Documented in `spa-mpa.md` with a recommendation to measure first. Per-page scoping would need a per-entry module graph and is deliberately out of scope here.

## Open decision for review

The relative-base gap is currently **warned but not auto-closed**. Gating the widening on `!importMapCapable` instead of `importMapIntegrity === false` would close it automatically, but would silently start eager-fetching the full module graph for every relative-base and manifest-alongside-HTML build. As shipped, those builds get a warning naming the affected chunks plus the one-line fix. Happy to flip it if reviewers prefer.

## Testing

465 tests pass (from 455), lint clean, no `src/` type errors, build and docs site both succeed. Coverage 95.3% statements / 92.9% branches, with `src/index.ts` at 100% statements.

New tests cover: the widened set closing the static-import gap, no inline script when disabled, the default path unchanged, `skipResources` honoured on both channels, `crossorigin` propagation, document-relative hrefs for nested HTML under a relative base, absolute/root-relative bases staying document-independent, and the warning firing at stock defaults on a relative base while staying quiet once coverage is complete.
