### PR TITLE
fix: minify the SRI runtime injected into consumer bundles (#45)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,9 @@ import {
 	installSriRuntime,
 	IntegrityProcessor,
 	isImportMapCapableBase,
+	loadVite,
 	ManifestProcessor,
+	minifyRuntimeSource,
 	validateGenerateBundleInputs,
 } from "./internal";
 
@@ -62,7 +64,14 @@ export interface SriPluginOptions {
 	 * private to other pages.
 	 */
 	importMapIntegrity?: boolean;
-	/** Inject a tiny runtime that sets integrity on dynamically inserted <script>/<link>. Default: true */
+	/**
+	 * Inject a tiny runtime that sets integrity on dynamically inserted
+	 * <script>/<link>. Default: true.
+	 *
+	 * The runtime is minified before injection, independently of how the rest of
+	 * the bundle is built, because it is added after the minification stage runs.
+	 * Setting Vite's `build.minify: false` opts it out along with everything else.
+	 */
 	runtimePatchDynamicLinks?: boolean;
 	/** Skip SRI generation for resources matching these patterns. Supports exact matches and simple glob patterns with '*'. */
 	skipResources?: string[];
@@ -130,12 +139,20 @@ export function rewriteDynamicImports(code: string): string {
  * to the runtime so integrity lookups can strip the base prefix from URLs
  * observed at runtime — the integrity map keys are '/'-rooted bundle file
  * names that never include the base.
+ *
+ * @param runtime - Either the runtime function (serialized here via
+ * `.toString()`) or already-serialized source. The plugin passes source that
+ * has been through `minifyRuntimeSource` first, which is why this accepts a
+ * string; passing the function directly yields the unminified form.
+ * @returns The complete statement to prepend to an entry chunk.
  */
 export function buildSriRuntimeCode(
-	runtime: (
-		sriByPathname: Record<string, string>,
-		opts?: Record<string, unknown>
-	) => void,
+	runtime:
+		| ((
+				sriByPathname: Record<string, string>,
+				opts?: Record<string, unknown>
+		  ) => void)
+		| string,
 	sriByPathname: Record<string, string>,
 	opts: {
 		crossorigin: "anonymous" | "use-credentials" | undefined;
@@ -156,9 +173,18 @@ export function buildSriRuntimeCode(
 	);
 	const serializedBase = escapeForScript(JSON.stringify(opts.base ?? "/"));
 	const args = `${serializedMap}, { crossorigin: ${cors}, skipResources: ${serializedSkipPatterns}, enforceDynamicImports: ${opts.enforceDynamicImports}, base: ${serializedBase} }`;
+	// A pre-serialized string is accepted so the caller can run the source
+	// through minifyRuntimeSource (async) while this stays a synchronous,
+	// side-effect-free string assembler. `args` is deliberately never minified:
+	// a minifier parses escapeForScript's `<` back to a plain `<` and re-emits
+	// it in whatever form it prefers, which would leave script-breakout safety
+	// to the minifier's heuristics instead of the explicit escaping above. The
+	// arguments are single-line JSON anyway, so there is nothing to reclaim.
+	const runtimeSource =
+		typeof runtime === "string" ? runtime : runtime.toString();
 	// Self-containment shim — see the doc comment above for why this is needed.
 	const shim = "var __name=function(fn){return fn;};";
-	return `\n(function(){${shim}return (${runtime.toString()});})()(${args});\n`;
+	return `\n(function(){${shim}return (${runtimeSource});})()(${args});\n`;
 }
 
 /**
@@ -187,6 +213,13 @@ export default function sri(options: SriPluginOptions = {}): PluginOption {
 
 	// Build-time state
 	let base = "/";
+	// The consumer's project root; anchors Vite resolution when this plugin is
+	// symlinked into the project (see loadVite).
+	let viteRoot = process.cwd();
+	// Mirrors the consumer's `build.minify`. Only an explicit `false` disables
+	// minification of the injected runtime; every other value ("esbuild",
+	// "terser", "oxc", true) leaves it enabled.
+	let minifyRuntime = true;
 	let sriByPathname: Record<string, string> = {};
 	let dynamicChunkFiles: Set<string> = new Set();
 
@@ -200,6 +233,8 @@ export default function sri(options: SriPluginOptions = {}): PluginOption {
 			// Fallback SSR detection from resolved config (may be a string or boolean)
 			isSSR = isSSR || !!config.build?.ssr;
 			base = config.base ?? "/";
+			minifyRuntime = config.build?.minify !== false;
+			viteRoot = config.root || process.cwd();
 
 			// Validate algorithm at runtime and fallback safely
 			if (
@@ -375,8 +410,20 @@ export default function sri(options: SriPluginOptions = {}): PluginOption {
 						// Step 2b: Inject runtime into entry chunks (BEFORE hashing entry chunks)
 						// The runtime contains hashes for dynamic chunks so they can be verified at load time
 						logger.info("Injecting SRI runtime into entry chunks");
+						// Minified separately from the assembly step below so the
+						// escaped JSON arguments never pass through a minifier.
+						// Honours the consumer's `build.minify: false`: someone
+						// who asked for a readable bundle wants this readable
+						// too, and 4 KB is irrelevant in a debug build.
+						const runtimeSource = minifyRuntime
+							? await minifyRuntimeSource(
+								installSriRuntime.toString(),
+								logger,
+								() => loadVite(viteRoot)
+							  )
+							: installSriRuntime.toString();
 						const runtimeCode = buildSriRuntimeCode(
-							installSriRuntime,
+							runtimeSource,
 							nonEntryHashes,
 							{
 								crossorigin,

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -1,5 +1,7 @@
 import { createHash } from "node:crypto";
+import { createRequire } from "node:module";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import type { DefaultTreeAdapterTypes, Token } from "parse5";
 import { parse, serialize } from "parse5";
 import type { Rollup } from "vite";
@@ -2618,6 +2620,162 @@ export class ManifestProcessor {
 // =======================================================
 // #region RUNTIME SRI INJECTION
 // =======================================================
+
+/** Synthetic filename reported to the minifier for diagnostics only. */
+const RUNTIME_FILENAME = "sri-runtime.js";
+
+/**
+ * The minifier surface this module needs from Vite. Both members are optional:
+ * which one exists depends on the consumer's Vite major.
+ */
+export interface ViteMinifiers {
+	/** Vite 8+: rolldown's (OXC) minifier, re-exported as first-class Vite API. */
+	minifySync?: (
+		filename: string,
+		source: string
+	) => { code: string } | undefined;
+	/** Vite 4-7: esbuild, which those versions depend on directly. */
+	transformWithEsbuild?: (
+		source: string,
+		filename: string,
+		options: Record<string, unknown>
+	) => Promise<{ code: string }>;
+}
+
+/**
+ * Loads Vite so its minifier can be borrowed for the injected runtime.
+ *
+ * A bare `import("vite")` covers npm, pnpm and Yarn PnP: `vite` is this
+ * plugin's declared peer dependency, so every linker is obliged to expose it to
+ * us. It does NOT cover a symlinked plugin (`npm link`, or a `file:` dependency
+ * pointing outside the consumer's tree): Node resolves this module to its
+ * realpath before walking `node_modules` ancestry, and that realpath has no
+ * Vite above it. The consumer's project root always does, so resolving from
+ * there recovers the symlinked case.
+ *
+ * Ordering matters. The bare import is the broadly-verified path and stays
+ * primary; the root anchor runs only once it has failed.
+ *
+ * The fallback resolves `vite/package.json` and targets the ESM entry by path
+ * rather than resolving the `vite` specifier itself. `createRequire().resolve`
+ * applies CJS conditions, and Vite 4-6 map those to an `index.cjs` shim that
+ * prints a CJS-deprecation warning into the consumer's build the moment it is
+ * loaded. Every major from 4 to 8 places the ESM entry at the same path, and
+ * `vite/package.json` is an exported subpath in all of them. If either
+ * assumption ever breaks, the import throws and the caller keeps the
+ * unminified source — the same outcome as having no fallback at all.
+ *
+ * @param root - The consumer's resolved `config.root`
+ * @param primary - Injected primary importer (defaults to `import("vite")`)
+ */
+export async function loadVite(
+	root: string,
+	primary: () => Promise<unknown> = () => import("vite")
+): Promise<ViteMinifiers> {
+	try {
+		return (await primary()) as ViteMinifiers;
+	} catch {
+		const req = createRequire(
+			pathToFileURL(path.join(root, "package.json")).href
+		);
+		const viteDir = path.dirname(req.resolve("vite/package.json"));
+		return (await import(
+			pathToFileURL(path.join(viteDir, "dist", "node", "index.js")).href
+		)) as ViteMinifiers;
+	}
+}
+
+/**
+ * Minifies the serialized SRI runtime at the CONSUMER's build time.
+ *
+ * `installSriRuntime` is not build-time-only code: it is serialized with
+ * `.toString()` and prepended to every entry chunk, so its source bytes are
+ * shipped to browsers. This plugin publishes its own `dist` unminified on
+ * purpose (see tsup.config.ts), and the consumer's minifier cannot reclaim
+ * those bytes either, because the runtime is injected in `generateBundle`,
+ * which runs after the `renderChunk` hooks where minification happens. Left
+ * alone that costs ~8.8 KB per entry chunk at default settings against ~4.3 KB
+ * minified, a little under half (issue #45).
+ *
+ * When measuring this, note that importing the plugin by absolute/relative path
+ * in a scratch `vite.config` understates the unminified figure by ~15%: Vite's
+ * config loader bundles path imports and reprints this module before
+ * `.toString()` reads it. Bare specifiers stay external, so a real install sees
+ * the full size.
+ *
+ * The minifier is reached through `vite` rather than by importing `esbuild` or
+ * `rolldown` directly. That is deliberate: `vite` is this plugin's declared
+ * peer dependency, so it resolves from the plugin's own scope under every
+ * package manager, whereas a bare `import("esbuild")` is a phantom dependency
+ * that fails under pnpm and Yarn PnP — silently disabling this optimisation
+ * for a large share of consumers. Vite re-exports whichever minifier its major
+ * ships with, so going through it also covers both eras with one import.
+ *
+ * `minifySync` is tried first because `transformWithEsbuild` is deprecated on
+ * Vite 8: it warns when esbuild happens to be installed, and throws outright
+ * when it is not — which is the common case there, since Vite 8 demoted esbuild
+ * to an optional peer. Capability detection keeps that branch unreachable on
+ * Vite 8, and the surrounding catch makes the failure harmless if it is ever
+ * reached anyway.
+ *
+ * `target: "esnext"` is load-bearing, not cosmetic. Downlevelling makes esbuild
+ * hoist helpers (`__async`, `__spreadValues`, ...) ABOVE the function and
+ * therefore outside the serialized text, reproducing the undefined-helper
+ * failure of issue #30. `keepNames: false` is pinned for the same reason — that
+ * transform is what caused #30 in the first place. The `startsWith("function")`
+ * guard is the backstop: any output that grew a prologue is discarded in favour
+ * of the original source, which is always self-contained.
+ *
+ * Every failure path returns `source` unchanged, which is exactly the behaviour
+ * that shipped before minification existed.
+ *
+ * @param source - `installSriRuntime.toString()`
+ * @param logger - Optional logger; failures are reported at info level
+ * @param load - Injected Vite loader (defaults to the real `vite` import)
+ */
+export async function minifyRuntimeSource(
+	source: string,
+	logger?: BundleLogger,
+	load: () => Promise<ViteMinifiers> = () => import("vite")
+): Promise<string> {
+	try {
+		const vite = await load();
+		let minified: string | undefined;
+
+		if (typeof vite.minifySync === "function") {
+			minified = vite.minifySync(RUNTIME_FILENAME, source)?.code;
+		} else if (typeof vite.transformWithEsbuild === "function") {
+			minified = (
+				await vite.transformWithEsbuild(source, RUNTIME_FILENAME, {
+					minify: true,
+					target: "esnext",
+					keepNames: false,
+				})
+			)?.code;
+		} else {
+			logger?.info(
+				"SRI runtime minification skipped: this Vite version exposes no minifier"
+			);
+			return source;
+		}
+
+		const trimmed = typeof minified === "string" ? minified.trim() : "";
+		if (!trimmed.startsWith("function")) {
+			logger?.info(
+				"SRI runtime minification skipped: minifier output was not a bare function declaration"
+			);
+			return source;
+		}
+		return trimmed;
+	} catch (err) {
+		logger?.info(
+			`SRI runtime minification skipped: ${
+				err instanceof Error ? err.message : String(err)
+			}`
+		);
+		return source;
+	}
+}
 
 /**
  * Runtime helper injected into entry chunks to add SRI to dynamically inserted elements.

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,7 +1,11 @@
 import vm from "node:vm";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import sri, { buildSriRuntimeCode, rewriteDynamicImports } from "../src/index";
-import { installSriRuntime, installSriRuntimeWithDeps } from "../src/internal";
+import {
+	installSriRuntime,
+	installSriRuntimeWithDeps,
+	minifyRuntimeSource,
+} from "../src/internal";
 import {
 	createMockPluginContext,
 	spyOnConsole,
@@ -2417,7 +2421,7 @@ describe("vite-plugin-sri-gen", () => {
 });
 
 describe("buildSriRuntimeCode (issue #30: self-contained injected runtime)", () => {
-	it("installs the global even when the serialized runtime references esbuild's __name helper", () => {
+	it("installs the global even when the serialized runtime references esbuild's __name helper", async () => {
 		// The plugin is bundled with esbuild's keepNames transform, which wraps
 		// named function expressions in a module-scoped `__name(fn, "name")`
 		// helper. That helper is NOT part of `installSriRuntime.toString()`, so
@@ -2453,12 +2457,17 @@ describe("buildSriRuntimeCode (issue #30: self-contained injected runtime)", () 
 		expect(typeof sandbox.__sriImport).toBe("function");
 	});
 
-	it("installs globalThis.__sriImport from the real runtime when enforcement is enabled", () => {
+	it("installs globalThis.__sriImport from the real runtime when enforcement is enabled", async () => {
 		// Positive/smoke test for the real runtime. Note: vitest transforms `src`
 		// without esbuild's keepNames, so the real `installSriRuntime.toString()`
 		// here contains no `__name`; this test therefore passes with or without
 		// the shim. The preceding test (synthetic `__name`) is the actual
 		// regression guard for issue #30.
+		//
+		// It also exercises the minified runtime end to end: a minifier that
+		// hoisted a helper out of the serialized function would leave the
+		// reference dangling here, so this doubles as the self-containment guard
+		// for issue #45's minification step.
 		const code = buildSriRuntimeCode(
 			installSriRuntime,
 			{ "/chunk.js": "sha384-abc" },
@@ -2488,7 +2497,7 @@ describe("buildSriRuntimeCode (issue #30: self-contained injected runtime)", () 
 		expect(typeof sandbox.__sriImport).toBe("function");
 	});
 
-	it("preserves the runtime arguments and the installSriRuntime source", () => {
+	it("preserves the runtime arguments and the installSriRuntime source", async () => {
 		const code = buildSriRuntimeCode(
 			installSriRuntime,
 			{ "/a.js": "sha384-x" },
@@ -2505,7 +2514,7 @@ describe("buildSriRuntimeCode (issue #30: self-contained injected runtime)", () 
 		expect(code).toContain('{"/a.js":"sha384-x"}');
 	});
 
-	it("serializes the base option into the injected runtime arguments", () => {
+	it("serializes the base option into the injected runtime arguments", async () => {
 		const code = buildSriRuntimeCode(
 			installSriRuntime,
 			{ "/assets/lazy.js": "sha256-abc" },
@@ -2519,7 +2528,7 @@ describe("buildSriRuntimeCode (issue #30: self-contained injected runtime)", () 
 		expect(code).toContain('base: "/app/"');
 	});
 
-	it("defaults the serialized base to '/' when not provided", () => {
+	it("defaults the serialized base to '/' when not provided", async () => {
 		const code = buildSriRuntimeCode(
 			installSriRuntime,
 			{ "/a.js": "sha384-x" },
@@ -2532,7 +2541,159 @@ describe("buildSriRuntimeCode (issue #30: self-contained injected runtime)", () 
 		expect(code).toContain('base: "/"');
 	});
 
-	it("escapes `<` in serialized data so it cannot break out of the injected script", () => {
+	it("leaves the injected runtime unminified when the consumer disables build.minify", async () => {
+		// A consumer who asked for a readable bundle wants this readable too —
+		// the 4 KB it costs is irrelevant in a build they are reading. Any other
+		// value ("esbuild", "terser", "oxc", true) leaves minification on.
+		const build = async (minify: unknown) => {
+			const plugin = sri() as any;
+			plugin.configResolved?.call(createMockPluginContext().context, {
+				command: "build",
+				mode: "production",
+				base: "/",
+				build: { minify },
+			} as any);
+			const bundle: any = {
+				"index.html": {
+					type: "asset",
+					fileName: "index.html",
+					source: htmlDoc(
+						'<script type="module" src="/assets/entry.js"></script>'
+					),
+				},
+				"assets/entry.js": makeEntryChunk(),
+			};
+			await plugin.generateBundle.handler.call(
+				createMockPluginContext().context,
+				{},
+				bundle
+			);
+			return bundle["assets/entry.js"].code as string;
+		};
+
+		expect(await build(false)).toMatch(/\n[ \t]+/);
+		expect(await build("esbuild")).not.toMatch(/\n[ \t]+/);
+	});
+
+	it("forwards arguments through the patched DOM methods after minification", async () => {
+		// The runtime patches setAttribute/appendChild with non-arrow
+		// `function(){...arguments...}` expressions. If a minifier ever
+		// arrow-converted one, `arguments` would rebind to the enclosing
+		// installSriRuntime(sriByPathname, opts) scope and the original method
+		// would silently receive the wrong values. Asserting only that install
+		// succeeds cannot catch that — the patched methods have to be called.
+		const source = await minifyRuntimeSource(installSriRuntime.toString());
+		const code = buildSriRuntimeCode(
+			source,
+			{ "/assets/lazy.js": "sha384-abc" },
+			{
+				crossorigin: "anonymous",
+				skipResources: [],
+				enforceDynamicImports: true,
+			}
+		);
+
+		const setAttrCalls: unknown[][] = [];
+		const appendCalls: unknown[][] = [];
+		function El(this: any) {}
+		El.prototype.setAttribute = function (...args: unknown[]) {
+			setAttrCalls.push(args);
+			return "orig-result";
+		};
+		function NodeCtor(this: any) {}
+		NodeCtor.prototype = {
+			appendChild(...args: unknown[]) {
+				appendCalls.push(args);
+				return args[0];
+			},
+		};
+		const sandbox: any = {
+			Element: El,
+			Node: NodeCtor,
+			HTMLLinkElement: function Link(this: any) {},
+			HTMLScriptElement: function Script(this: any) {},
+		};
+		vm.createContext(sandbox);
+		vm.runInContext(code, sandbox);
+
+		// Drive the patched methods through the sandbox so the minified copies
+		// are the ones under test, not this file's in-process originals.
+		vm.runInContext(
+			`
+			globalThis.el = new Element();
+			globalThis.setAttrReturn = el.setAttribute("data-foo", "bar");
+			globalThis.child = { nodeName: "DIV" };
+			globalThis.appendReturn = Node.prototype.appendChild.call(el, child);
+			`,
+			sandbox
+		);
+
+		expect(setAttrCalls).toEqual([["data-foo", "bar"]]);
+		expect(sandbox.setAttrReturn).toBe("orig-result");
+		expect(appendCalls).toEqual([[sandbox.child]]);
+		expect(sandbox.appendReturn).toBe(sandbox.child);
+	});
+
+	it("still rejects a hash mismatch after minification", async () => {
+		// Guards against a minifier dead-code-eliminating or short-circuiting the
+		// integrity comparison. Without this, a minified runtime that verified
+		// nothing would pass every text-based assertion in this file.
+		const source = await minifyRuntimeSource(installSriRuntime.toString());
+		const code = buildSriRuntimeCode(
+			source,
+			{ "/assets/lazy.js": "sha384-" + "A".repeat(64) },
+			{
+				crossorigin: "anonymous",
+				skipResources: [],
+				enforceDynamicImports: true,
+			}
+		);
+
+		const sandbox: any = {
+			location: { href: "https://example.test/index.html" },
+			fetch: async () => ({
+				ok: true,
+				arrayBuffer: async () => new TextEncoder().encode("payload").buffer,
+			}),
+			crypto: globalThis.crypto,
+			btoa: globalThis.btoa,
+			TextEncoder,
+			URL,
+		};
+		vm.createContext(sandbox);
+		vm.runInContext(code, sandbox);
+		expect(typeof sandbox.__sriImport).toBe("function");
+
+		// The map above pins a hash that "payload" cannot produce, so the
+		// verifier must refuse rather than importing it.
+		await expect(
+			sandbox.__sriImport(
+				"https://example.test/assets/entry.js",
+				"/assets/lazy.js"
+			)
+		).rejects.toThrow(/Integrity verification failed/);
+	});
+
+	it("accepts pre-serialized runtime source so the caller can minify it first", () => {
+		// The plugin passes minified source rather than the function itself, so
+		// the assembler must treat a string as already-serialized rather than
+		// calling .toString() on it and embedding a quoted string literal.
+		const code = buildSriRuntimeCode(
+			"function fake(){globalThis.__sriImport=function(){};}",
+			{ "/a.js": "sha384-x" },
+			{
+				crossorigin: "anonymous",
+				skipResources: [],
+				enforceDynamicImports: true,
+			}
+		);
+		const sandbox: any = {};
+		vm.createContext(sandbox);
+		vm.runInContext(code, sandbox);
+		expect(typeof sandbox.__sriImport).toBe("function");
+	});
+
+	it("escapes `<` in serialized data so it cannot break out of the injected script", async () => {
 		const code = buildSriRuntimeCode(
 			installSriRuntime,
 			{ "/a</script>b.js": "sha384-x", "/normal path.js": "sha384-y" },

--- a/test/internal.spec.ts
+++ b/test/internal.spec.ts
@@ -17,6 +17,8 @@ import {
 	isEligibleForSri,
 	isHttpUrl,
 	isImportMapCapableBase,
+	loadVite,
+	minifyRuntimeSource,
 	buildImportIntegrityObject,
 	collectModuleChunkFiles,
 	joinBaseHref,
@@ -6014,5 +6016,196 @@ describe("collectModuleChunkFiles", () => {
 		// base is usable here even though it yields no valid import map.
 		expect(buildImportIntegrityObject(sriByPathname, "./")).toBeNull();
 		expect(collectModuleChunkFiles(sriByPathname).length).toBe(2);
+	});
+});
+
+describe("minifyRuntimeSource (issue #45: injected runtime ships minified)", () => {
+	const SOURCE = "function installSriRuntime(a, b) {\n\treturn a + b;\n}";
+
+	// Vite 8+ re-exports rolldown's minifier; Vite 4-7 expose esbuild via
+	// transformWithEsbuild. The loader is injected so each era — and each
+	// failure mode — is reachable without depending on what happens to be
+	// installed in this repo, where esbuild is always present via tsup.
+	const viteWithMinifySync = (code: string, spy = vi.fn()) => () =>
+		Promise.resolve({
+			minifySync: (...args: unknown[]) => {
+				spy(...args);
+				return { code };
+			},
+		});
+
+	const viteWithEsbuild = (code: string, spy = vi.fn()) => () =>
+		Promise.resolve({
+			transformWithEsbuild: async (...args: unknown[]) => {
+				spy(...args);
+				return { code };
+			},
+		});
+
+	it("uses Vite's minifySync when present (Vite 8+)", async () => {
+		const spy = vi.fn();
+		const out = await minifyRuntimeSource(
+			SOURCE,
+			undefined,
+			viteWithMinifySync("function installSriRuntime(a,b){return a+b}", spy)
+		);
+		expect(out).toBe("function installSriRuntime(a,b){return a+b}");
+		expect(spy).toHaveBeenCalledWith("sri-runtime.js", SOURCE);
+	});
+
+	it("prefers minifySync over transformWithEsbuild when Vite exposes both", async () => {
+		// transformWithEsbuild still exists on Vite 8 but is deprecated there and
+		// prints a warning into every consumer build, so it must not be reached.
+		const esbuildSpy = vi.fn();
+		const out = await minifyRuntimeSource(SOURCE, undefined, () =>
+			Promise.resolve({
+				minifySync: () => ({ code: "function fromMinifySync(){}" }),
+				transformWithEsbuild: async (...args: unknown[]) => {
+					esbuildSpy(...args);
+					return { code: "function fromEsbuild(){}" };
+				},
+			})
+		);
+		expect(out).toBe("function fromMinifySync(){}");
+		expect(esbuildSpy).not.toHaveBeenCalled();
+	});
+
+	it("falls back to transformWithEsbuild when minifySync is absent (Vite 4-7)", async () => {
+		const spy = vi.fn();
+		const out = await minifyRuntimeSource(
+			SOURCE,
+			undefined,
+			viteWithEsbuild("function installSriRuntime(a,b){return a+b}", spy)
+		);
+		expect(out).toBe("function installSriRuntime(a,b){return a+b}");
+		expect(spy).toHaveBeenCalledWith(SOURCE, "sri-runtime.js", {
+			// Pinned deliberately: downlevelling hoists esbuild helpers above the
+			// function, outside the serialized text, which is what broke issue #30.
+			// keepNames is the transform that caused #30 in the first place.
+			minify: true,
+			target: "esnext",
+			keepNames: false,
+		});
+	});
+
+	it("rejects minifier output that grew a prologue and keeps the original source", async () => {
+		// The real shape this guards: a downlevelling minifier hoists `__async`
+		// above the function, so the serialized text would reference a helper
+		// that does not exist in the consumer's bundle.
+		const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), summary: vi.fn() };
+		const out = await minifyRuntimeSource(
+			SOURCE,
+			logger,
+			viteWithMinifySync(
+				"var __async=(a,b)=>new Promise(a);function installSriRuntime(a,b){return a+b}"
+			)
+		);
+		expect(out).toBe(SOURCE);
+		expect(logger.info).toHaveBeenCalledWith(
+			expect.stringContaining("not a bare function declaration")
+		);
+	});
+
+	it("keeps the original source when Vite exposes no minifier at all", async () => {
+		const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), summary: vi.fn() };
+		const out = await minifyRuntimeSource(SOURCE, logger, () =>
+			Promise.resolve({})
+		);
+		expect(out).toBe(SOURCE);
+		expect(logger.info).toHaveBeenCalledWith(
+			expect.stringContaining("no minifier")
+		);
+	});
+
+	it("keeps the original source and reports why when the minifier throws", async () => {
+		const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), summary: vi.fn() };
+		const out = await minifyRuntimeSource(SOURCE, logger, () =>
+			Promise.resolve({
+				minifySync: () => {
+					throw new Error("boom");
+				},
+			})
+		);
+		expect(out).toBe(SOURCE);
+		// The reason must survive: a silent catch made a broken minifier
+		// integration indistinguishable from one that was simply absent.
+		expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("boom"));
+	});
+
+	it("reports a non-Error throwable without losing the original source", async () => {
+		const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), summary: vi.fn() };
+		const out = await minifyRuntimeSource(SOURCE, logger, () =>
+			Promise.resolve({
+				minifySync: () => {
+					throw "plain string failure";
+				},
+			})
+		);
+		expect(out).toBe(SOURCE);
+		expect(logger.info).toHaveBeenCalledWith(
+			expect.stringContaining("plain string failure")
+		);
+	});
+
+	it("keeps the original source when Vite itself cannot be loaded", async () => {
+		const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), summary: vi.fn() };
+		const out = await minifyRuntimeSource(SOURCE, logger, () =>
+			Promise.reject(new Error("Cannot find package 'vite'"))
+		);
+		expect(out).toBe(SOURCE);
+		expect(logger.info).toHaveBeenCalledWith(
+			expect.stringContaining("Cannot find package")
+		);
+	});
+
+	it("tolerates a minifier that returns no code", async () => {
+		const out = await minifyRuntimeSource(SOURCE, undefined, () =>
+			Promise.resolve({ minifySync: () => undefined })
+		);
+		expect(out).toBe(SOURCE);
+	});
+
+	it("actually minifies the real runtime through the installed Vite", async () => {
+		// End-to-end against whatever minifier this environment really has, so a
+		// break in the default loader is caught rather than mocked around.
+		const out = await minifyRuntimeSource(installSriRuntime.toString());
+		expect(out.startsWith("function")).toBe(true);
+		expect(out).not.toMatch(/\n[ \t]+/);
+		// Comment-stripped-but-indented source is ~8 KB; real minification is
+		// ~4.3 KB. A threshold below that gap fails a whitespace-only collapse.
+		expect(out.length).toBeLessThan(6000);
+	});
+});
+
+describe("loadVite (issue #45: reaching Vite's minifier under every linker)", () => {
+	it("returns Vite from the plain import when that resolves", async () => {
+		const vite = await loadVite("/nonexistent-root-never-used");
+		// The bare import is the primary path; the unusable root proves the
+		// fallback was not consulted.
+		expect(typeof vite.minifySync === "function" ||
+			typeof vite.transformWithEsbuild === "function").toBe(true);
+	});
+
+	it("falls back to the project root when the plugin is symlinked out of Vite's reach", async () => {
+		// `npm link` (and a `file:` dependency outside the consumer's tree) makes
+		// Node resolve this module to its realpath before walking node_modules,
+		// and that realpath has no Vite above it. The consumer's root always does.
+		const vite = await loadVite(process.cwd(), () =>
+			Promise.reject(
+				new Error("ERR_MODULE_NOT_FOUND Cannot find package 'vite'")
+			)
+		);
+		expect(typeof vite.minifySync === "function" ||
+			typeof vite.transformWithEsbuild === "function").toBe(true);
+	});
+
+	it("propagates the failure when neither path can reach Vite", async () => {
+		// minifyRuntimeSource catches this and keeps the unminified source; the
+		// loader itself must not swallow it silently.
+		await expect(
+			loadVite("/nonexistent-root", () =>
+				Promise.reject(new Error("no vite"))
+			)
+		).rejects.toThrow();
 	});
 });

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -12,11 +12,16 @@ export default defineConfig({
   splitting: false,
   sourcemap: true,
   bundle: true,
+  // minify stays off so the published package remains auditable (Socket.dev
+  // flags minified code). The one piece of this bundle that reaches browsers —
+  // `installSriRuntime`, serialized into consumer entry chunks — is minified at
+  // the consumer's build time instead, by buildSriRuntimeCode() (issue #45).
+  //
   // keepNames is intentionally disabled: esbuild's keepNames transform injects
   // a module-scoped `__name` helper into named function expressions. Because
   // `installSriRuntime` is shipped to consumer bundles via `.toString()`, those
   // `__name(...)` references would be undefined in the consumer and break the
-  // injected runtime (issue #30). The build is unminified, so keepNames has no
-  // benefit here anyway. buildSriRuntimeCode() also shims `__name` defensively.
+  // injected runtime (issue #30). buildSriRuntimeCode() also shims `__name`
+  // defensively, and rejects any minifier output that grew such a prologue.
   keepNames: false,
 })


### PR DESCRIPTION
Closes #45.

## Problem

`installSriRuntime` is serialized with `.toString()` and prepended to every entry chunk, so its **source bytes ship to browsers**. Those bytes were the plugin's own pretty-printed `dist` output — measured end to end against a real build, **8818 bytes per entry chunk against 4532 minified**, on the default settings (`runtimePatchDynamicLinks` defaults to `true`, so this is the stock path, not an opt-in one).

Neither minifier could reclaim them:

- This package publishes `dist` **unminified on purpose** (#27, so Socket.dev doesn't flag it and the code stays auditable). That decision assumed *"the plugin runs at build time so size impact is negligible"* — which has a hole: this one function is not build-time-only.
- The consumer's own minifier never sees it either, because the runtime is injected in `generateBundle`, which runs **after** the `renderChunk` hooks where minification happens.

## Change

Minify at the *consumer's* build time, so the published `dist` stays readable and the browser payload halves.

The minifier is reached **through `vite`**, not by importing `esbuild` or `rolldown` directly. `vite` is this plugin's declared peer dependency, so every linker is obliged to expose it. Vite re-exports whichever minifier its major ships with — `minifySync` on 8+, `transformWithEsbuild` on 4–7 — so one import covers both eras. `minifySync` is tried first because `transformWithEsbuild` is deprecated on Vite 8, where it *warns* when esbuild is installed and *throws outright* when it isn't.

> The issue suggests `transformWithOxc`. That doesn't work — it has no minifier (8575 → 7569 bytes, pure reformatting).

### Three ways bare-specifier resolution silently fails

The first implementation used `import("esbuild")` with a `rolldown/experimental` fallback. Review found three distinct mechanisms that each make that a no-op — all of which fail *safely* (correct build, correct hashes, just no size win), which is exactly why they'd have shipped unnoticed:

| Mechanism | Effect |
|---|---|
| `esbuild`/`rolldown` are phantom dependencies — a package resolves only its **own** declared deps | No-op under **pnpm and Yarn PnP**, every Vite version. Confirmed on pnpm + Vite 5, where esbuild is a *hard* dep of Vite and still doesn't resolve |
| Node resolves symlinks to **realpath** before walking `node_modules` | No-op under **`npm link`** / `file:` deps outside the tree — this one defeats `import("vite")` too |
| Vite 4–6 map CJS conditions to an `index.cjs` shim that assigns exports in a `forEach` | `transformWithEsbuild` is invisible to `cjs-module-lexer`, so it isn't a named export — would no-op on **Vite 4/5**, and the shim prints a CJS-deprecation warning on load |

So the fallback for symlinked installs anchors on `config.root` (never itself a symlink) and targets Vite's ESM entry **by path** rather than resolving the `vite` specifier. `dist/node/index.js` is the ESM entry in every major 4–8. The bare import stays primary since it's the broadly-verified path; the anchor runs only after it fails.

Every failure path returns the source unchanged — the behaviour that shipped before — now with a **logged reason** instead of silence. The previous empty `catch {}` made "not installed" and "installed but broken" indistinguishable.

### Guards

- **`target: "esnext"` and `keepNames: false` are pinned.** Downlevelling hoists esbuild helpers (`__async`, `__spreadValues`) *above* the function and outside the serialized text — reproducing #30. `keepNames` is the transform that caused #30 in the first place.
- **Output that isn't a bare function declaration is discarded** in favour of the original source, catching a prologue however it arose.
- **Only the serialized function is minified, never the arguments.** A minifier parses `escapeForScript`'s escaped `<` back to a plain `<` and re-emits it however it prefers, which would leave script-breakout safety to the minifier's heuristics rather than the explicit escaping. (Verified: for `</script>` both minifiers defensively re-escape, but for a bare `<div>` both emit it raw.)

### `build.minify: false` is honoured

Someone who asked for a readable bundle wants this readable too, and 4 KB is irrelevant in a build they're reading — a fitting symmetry with why this package ships its own `dist` unminified. Only a strict `false` disables it; `"esbuild"`, `"terser"`, `"oxc"` and `true` all leave it on.

## API surface

**Unchanged — this is not a breaking change.** `buildSriRuntimeCode` stays synchronous returning `string`; its first parameter *widens* to `Function | string` so the caller can minify before assembly. `minifyRuntimeSource` and `loadVite` live in `internal.ts` and never reach `dist/index.d.ts`. The export list is the same four names.

## Testing

**482 tests pass** (from 467), lint clean, no `src/` type errors, build clean. New code has **zero coverage gaps**; `src/index.ts` is at 100% statements / 100% functions / 100% lines / 99% branches, the one uncovered branch being pre-existing.

Verified beyond the unit suite:

- **Zero hash mismatches** across four real `vite build` configurations — SHA-384 recomputed over every asset on disk and diffed against every `integrity=` in the HTML, inline import map, and manifest, including the `build.minify: false` path which assembles different bytes.
- The injected runtime **executes correctly in a real Chrome tab**: the fetch → `crypto.subtle.digest` → compare → native-import chain runs and passes with zero console errors.
- **`arguments` forwarding verified functionally** under both minifiers — the patched `setAttribute`/`appendChild`/`insertBefore`/`append` are actually invoked and asserted to receive correctly forwarded values, guarding against a minifier arrow-converting a `function(){...arguments...}` expression.
- **npm-link recovery confirmed on Vite 4, 5, 6, 7 and 8**, with no CJS-deprecation warning; **5/5 linker cells** (npm, pnpm×5, pnpm×8, Yarn PnP×5, Yarn PnP×8) regression-free with the primary path winning.
- Both new behavioural tests were **mutation-tested**: arrow-converting `setAttribute` and neutering the hash comparison each make them fail, so neither passes vacuously.

New tests cover both minifier eras, prologue rejection, no-minifier-available, minifier-throws, non-`Error` throwables, Vite-unloadable, the `loadVite` fallback, `build.minify: false` in both directions, `arguments` forwarding through the minified runtime, and a hash mismatch still being rejected after minification.

## Note for future measurement

Importing the plugin by absolute/relative path in a scratch `vite.config` understates the unminified figure by ~15% — Vite's config loader bundles path imports and reprints the module before `.toString()` reads it. Bare specifiers stay external, so a real install sees the full size. Recorded in the source comment, since it produced two conflicting measurements during review.
