### PR TITLE
fix: close coverage-warning gaps introduced by #54 and #55

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,6 @@ type NormalizedOutputOptions = Rollup.NormalizedOutputOptions;
 type OutputBundle = Rollup.OutputBundle;
 import type { BundleLogger } from "./internal";
 import {
-	collectChunkFileNames,
 	collectModuleChunkFiles,
 	createLogger,
 	DynamicImportAnalyzer,
@@ -475,7 +474,9 @@ export default function sri(options: SriPluginOptions = {}): PluginOption {
 						// point walking the graph for manifest-only builds.
 						const redundantImportMapChunks =
 							dynamicImportAnalyzer.redundantImportMapChunks(
-								bundle
+								bundle,
+								base,
+								skipResources
 							);
 
 						// Never degrade coverage silently. Model every channel
@@ -500,18 +501,17 @@ export default function sri(options: SriPluginOptions = {}): PluginOption {
 						const moduleChunks = collectModuleChunkFiles(
 							sriByPathname,
 							skipResources,
-							redundantImportMapChunks,
-							collectChunkFileNames(bundle)
+							redundantImportMapChunks
 						).map((f) => f.fileName);
 						const covered = new Set<string>();
-						// A chunk referenced by an integrity-bearing HTML tag
-						// (a <script type="module"> or Vite's own
+						// A chunk every reaching page references via a stamped
+						// module tag (a <script type="module"> or Vite's own
 						// <link rel="modulepreload">) is already protected by the
-						// SRI attribute pass, regardless of base or channel. Not
-						// crediting these over-reported statically-imported chunks
-						// that Vite preloads (issue #52).
+						// SRI attribute pass, regardless of base or channel.
+						// Without this credit, statically-imported chunks that
+						// Vite preloads were over-reported (issue #52).
 						dynamicImportAnalyzer
-							.htmlTagReferencedChunks(bundle)
+							.htmlTagCoveredChunks(bundle, base, skipResources)
 							.forEach((f) => covered.add(f));
 						if (importMapCapable) {
 							moduleChunks.forEach((f) => covered.add(f));

--- a/src/index.ts
+++ b/src/index.ts
@@ -486,6 +486,16 @@ export default function sri(options: SriPluginOptions = {}): PluginOption {
 						// catch (relative base at stock defaults: no map, narrow
 						// preloads, no rewrite, and no warning).
 						//
+						// This models the EMITTED HTML: every channel below is
+						// injected into those pages, and the tag credit is read
+						// from them. A manifest emitted alongside HTML does not
+						// remove the import map from those pages — it only keeps
+						// the import() rewrite active for backend-rendered ones
+						// (see importMapCapable) — so the map is credited here
+						// whenever it is actually injected (issue #52 follow-up:
+						// base "/" plus build.manifest warned about chunks the
+						// map already covered).
+						//
 						// A module-graph chunk is covered when:
 						//  - the import map is emitted (covers every chunk), or
 						//  - modulepreload injection reaches it: the whole graph
@@ -517,7 +527,7 @@ export default function sri(options: SriPluginOptions = {}): PluginOption {
 							)
 						).map((f) => f.fileName);
 						const covered = new Set<string>();
-						if (importMapCapable) {
+						if (importMapIntegrity && isImportMapCapableBase(base)) {
 							moduleChunks.forEach((f) => covered.add(f));
 						}
 						if (preloadDynamicChunks) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -498,21 +498,25 @@ export default function sri(options: SriPluginOptions = {}): PluginOption {
 						//
 						// Gated on chunks actually existing, so a single-bundle
 						// build with no module-graph fetches stays quiet.
-						const moduleChunks = collectModuleChunkFiles(
-							sriByPathname,
-							skipResources,
-							redundantImportMapChunks
-						).map((f) => f.fileName);
-						const covered = new Set<string>();
+						//
 						// A chunk every reaching page references via a stamped
 						// module tag (a <script type="module"> or Vite's own
 						// <link rel="modulepreload">) is already protected by the
-						// SRI attribute pass, regardless of base or channel.
-						// Without this credit, statically-imported chunks that
-						// Vite preloads were over-reported (issue #52).
-						dynamicImportAnalyzer
-							.htmlTagCoveredChunks(bundle, base, skipResources)
-							.forEach((f) => covered.add(f));
+						// SRI attribute pass, regardless of base or channel, so
+						// it is excluded up front. Without this credit,
+						// statically-imported chunks that Vite preloads were
+						// over-reported (issue #52). redundantImportMapChunks is
+						// a subset of this set, so it needs no separate exclusion.
+						const moduleChunks = collectModuleChunkFiles(
+							sriByPathname,
+							skipResources,
+							dynamicImportAnalyzer.htmlTagCoveredChunks(
+								bundle,
+								base,
+								skipResources
+							)
+						).map((f) => f.fileName);
+						const covered = new Set<string>();
 						if (importMapCapable) {
 							moduleChunks.forEach((f) => covered.add(f));
 						}

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -846,9 +846,10 @@ export function findPreComputedHashKey(
 			if (has(stripped)) return stripped;
 		}
 	}
+	// pathname always carries a leading slash, so the bare form is the only
+	// normalized variant not already tried.
 	const normalizedPath = normalizeBundlePath(pathname) as string;
 	if (has(normalizedPath)) return normalizedPath;
-	if (has(`/${normalizedPath}`)) return `/${normalizedPath}`;
 	return undefined;
 }
 
@@ -1636,10 +1637,12 @@ export class DynamicImportAnalyzer {
 						idToFileMap,
 						bundle
 					);
+					// seen is seeded with every tagged chunk, so anything newly
+					// reached has no tag on this page.
 					if (!resolved || seen.has(resolved)) continue;
 					seen.add(resolved);
 					stack.push(resolved);
-					if (!refs.has(resolved)) unprotected.add(resolved);
+					unprotected.add(resolved);
 				}
 			}
 		}
@@ -1693,17 +1696,19 @@ export class DynamicImportAnalyzer {
 			for (const el of findElements(document, (node) =>
 				isEligibleForSri(node, skipResources)
 			)) {
-				// Strip query/hash so hashed-URL variants still match.
-				let url = getAttrValue(el, getUrlAttrName(el)!)?.split(
+				// Eligible tags always carry the URL attribute. Strip
+				// query/hash so hashed-URL variants still match.
+				let url = getAttrValue(el, getUrlAttrName(el)!)!.split(
 					/[?#]/
 				)[0];
-				if (!url) continue;
 				if (!isHttpUrl(url) && !url.startsWith("/")) {
 					url = path.posix.join(dir, url);
 				}
+				// inBundle accepts either key form, so a hit is always the
+				// slash-prefixed pathname tried first.
 				const key = findPreComputedHashKey(url, inBundle, base);
 				if (!key) continue;
-				const fileName = key.startsWith("/") ? key.slice(1) : key;
+				const fileName = key.slice(1);
 				if (bundle[fileName].type === "chunk" && !isModuleTag(el)) {
 					continue;
 				}

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -284,43 +284,18 @@ export function buildImportIntegrityObject(
 export function collectModuleChunkFiles(
 	sriByPathname: Record<string, string>,
 	skipResources: string[] = [],
-	excludeFileNames: Set<string> = new Set(),
-	chunkFileNames?: Set<string>
+	excludeFileNames: Set<string> = new Set()
 ): Array<{ pathname: string; fileName: string }> {
 	const files: Array<{ pathname: string; fileName: string }> = [];
 	for (const pathname of Object.keys(sriByPathname)) {
 		// Match PROCESSABLE_EXTENSIONS semantics: allow a query suffix.
 		if (!/\.m?js(\?|$)/i.test(pathname)) continue;
 		const fileName = pathname.startsWith("/") ? pathname.slice(1) : pathname;
-		// Preload injection only: a `.js` file emitted as a bundle ASSET (e.g.
-		// vite-plugin-pwa's registerSW.js, loaded via a classic <script>) is
-		// not a module — a modulepreload can never satisfy its classic fetch,
-		// so the browser discards the preload and refetches (issue #53). It
-		// stays in the import map and the coverage model, where an entry for a
-		// non-module fetch is inert but one for a `?url` import() is real
-		// coverage. Strip any query suffix first (the regex above allows one)
-		// so a chunk whose pathname carries `?v=…` still matches the queryless
-		// bundle keys.
-		if (chunkFileNames && !chunkFileNames.has(fileName.split(/[?#]/)[0]))
-			continue;
 		if (isSkippedResource(fileName, skipResources)) continue;
 		if (excludeFileNames.has(fileName)) continue;
 		files.push({ pathname, fileName });
 	}
 	return files;
-}
-
-/**
- * The set of emitted file names that are genuine Rollup chunks (type ===
- * "chunk"), as they key `sriByPathname`. Passed to collectModuleChunkFiles so a
- * `.js` bundle ASSET is never mistaken for a module chunk (issue #53).
- */
-export function collectChunkFileNames(bundle: OutputBundle): Set<string> {
-	const names = new Set<string>();
-	for (const [fileName, item] of Object.entries(bundle)) {
-		if (item?.type === "chunk") names.add(fileName);
-	}
-	return names;
 }
 
 /**
@@ -2054,6 +2029,11 @@ export class HtmlProcessor {
 		// import site (there is no syntax for it). Manufacturing a
 		// <link rel="modulepreload" integrity> is the only build-time way to
 		// attach a hash to that fetch. Cost: those chunks are fetched eagerly.
+		//
+		// Only genuine Rollup chunks are preloaded: a `.js` bundle ASSET (e.g.
+		// vite-plugin-pwa's registerSW.js, loaded via a classic <script>) is
+		// not a module, so a modulepreload can never satisfy its fetch and the
+		// browser discards it and refetches (issue #53).
 		const preloadFiles =
 			this.config.importMapIntegrity === false
 				? new Set([
@@ -2061,9 +2041,10 @@ export class HtmlProcessor {
 					...collectModuleChunkFiles(
 						sriByPathname,
 						this.config.skipResources,
-						redundantImportMapChunks,
-						collectChunkFileNames(bundle)
-					).map((f) => f.fileName),
+						redundantImportMapChunks
+					)
+						.map((f) => f.fileName)
+						.filter((f) => bundle[f]?.type === "chunk"),
 				])
 				: dynamicChunkFiles;
 

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -252,16 +252,14 @@ export function buildImportIntegrityObject(
 	sriByPathname: Record<string, string>,
 	base: string,
 	skipResources: string[] = [],
-	excludeFileNames: Set<string> = new Set(),
-	chunkFileNames?: Set<string>
+	excludeFileNames: Set<string> = new Set()
 ): Record<string, string> | null {
 	if (!isImportMapCapableBase(base)) return null;
 	const result: Record<string, string> = {};
 	for (const { pathname, fileName } of collectModuleChunkFiles(
 		sriByPathname,
 		skipResources,
-		excludeFileNames,
-		chunkFileNames
+		excludeFileNames
 	)) {
 		result[joinBaseHref(base, fileName)] = sriByPathname[pathname];
 	}
@@ -294,14 +292,15 @@ export function collectModuleChunkFiles(
 		// Match PROCESSABLE_EXTENSIONS semantics: allow a query suffix.
 		if (!/\.m?js(\?|$)/i.test(pathname)) continue;
 		const fileName = pathname.startsWith("/") ? pathname.slice(1) : pathname;
-		// Only genuine Rollup chunks belong in the module graph. A `.js` file
-		// emitted as a bundle ASSET (e.g. vite-plugin-pwa's registerSW.js,
-		// loaded via a classic <script>) is not a module — a modulepreload can
-		// never satisfy its classic fetch, so the browser discards the preload
-		// and refetches (issue #53). When the caller knows the chunk set, honour
-		// it; the extension test alone cannot tell a chunk from a `.js` asset.
-		// Strip any query suffix first (the regex above allows one) so a chunk
-		// whose pathname carries `?v=…` still matches the queryless bundle keys.
+		// Preload injection only: a `.js` file emitted as a bundle ASSET (e.g.
+		// vite-plugin-pwa's registerSW.js, loaded via a classic <script>) is
+		// not a module — a modulepreload can never satisfy its classic fetch,
+		// so the browser discards the preload and refetches (issue #53). It
+		// stays in the import map and the coverage model, where an entry for a
+		// non-module fetch is inert but one for a `?url` import() is real
+		// coverage. Strip any query suffix first (the regex above allows one)
+		// so a chunk whose pathname carries `?v=…` still matches the queryless
+		// bundle keys.
 		if (chunkFileNames && !chunkFileNames.has(fileName.split(/[?#]/)[0]))
 			continue;
 		if (isSkippedResource(fileName, skipResources)) continue;
@@ -811,40 +810,12 @@ export async function processElement(
 	// Check for pre-computed integrity hash first
 	let integrity: string | undefined;
 	if (preComputedHashes && resourcePath) {
-		// Extract pathname from resource URL (handles absolute CDN URLs)
-		const pathname = extractPathnameFromResourceUrl(resourcePath);
-
-		// Try to find a matching pre-computed hash
-		// Check exact pathname first, then try normalized versions
-		integrity = preComputedHashes[pathname];
-		if (!integrity && base) {
-			// Retry with the configured base's pathname stripped, mirroring
-			// the runtime's lookupIntegrityByPathname: hash keys are
-			// bundle-relative while sub-path and CDN-base deployments prefix
-			// URLs with the base (issue #50). Parsing the base to a
-			// trailing-slash pathname keeps the strip segment-aligned (a
-			// base of "/app" cannot truncate "/app-legacy/x.js") and matches
-			// protocol-relative URL forms of an absolute base.
-			let basePathname = "/";
-			try {
-				basePathname = new URL(base, "http://x/").pathname;
-				if (!basePathname.endsWith("/")) basePathname += "/";
-			} catch {
-				// Unparseable base (e.g. relative "./") — no stripping
-			}
-			if (basePathname !== "/" && pathname.startsWith(basePathname)) {
-				integrity =
-					preComputedHashes[
-						`/${pathname.slice(basePathname.length)}`
-					];
-			}
-		}
-		if (!integrity) {
-			const normalizedPath = normalizeBundlePath(pathname) as string;
-			integrity =
-				preComputedHashes[normalizedPath] ||
-				preComputedHashes[`/${normalizedPath}`];
-		}
+		const key = findPreComputedHashKey(
+			resourcePath,
+			(k) => !!preComputedHashes[k],
+			base
+		);
+		if (key) integrity = preComputedHashes[key];
 	}
 
 	// If no pre-computed hash found, compute it the traditional way
@@ -864,6 +835,46 @@ export async function processElement(
 	if (crossorigin) {
 		setAttrValue(element, "crossorigin", crossorigin);
 	}
+}
+
+/**
+ * Resolves a tag's src/href to the `sriByPathname` key the SRI pass will
+ * read its hash from, or undefined when no pre-computed hash matches.
+ * Tries the exact pathname, then the pathname with the configured base's
+ * pathname stripped, then the bundle-normalized forms.
+ */
+export function findPreComputedHashKey(
+	resourcePath: string,
+	has: (key: string) => boolean,
+	base?: string
+): string | undefined {
+	// Extract pathname from resource URL (handles absolute CDN URLs)
+	const pathname = extractPathnameFromResourceUrl(resourcePath);
+	if (has(pathname)) return pathname;
+	if (base) {
+		// Retry with the configured base's pathname stripped, mirroring
+		// the runtime's lookupIntegrityByPathname: hash keys are
+		// bundle-relative while sub-path and CDN-base deployments prefix
+		// URLs with the base (issue #50). Parsing the base to a
+		// trailing-slash pathname keeps the strip segment-aligned (a
+		// base of "/app" cannot truncate "/app-legacy/x.js") and matches
+		// protocol-relative URL forms of an absolute base.
+		let basePathname = "/";
+		try {
+			basePathname = new URL(base, "http://x/").pathname;
+			if (!basePathname.endsWith("/")) basePathname += "/";
+		} catch {
+			// Unparseable base (e.g. relative "./") — no stripping
+		}
+		if (basePathname !== "/" && pathname.startsWith(basePathname)) {
+			const stripped = `/${pathname.slice(basePathname.length)}`;
+			if (has(stripped)) return stripped;
+		}
+	}
+	const normalizedPath = normalizeBundlePath(pathname) as string;
+	if (has(normalizedPath)) return normalizedPath;
+	if (has(`/${normalizedPath}`)) return `/${normalizedPath}`;
+	return undefined;
 }
 
 /**
@@ -906,6 +917,21 @@ export function isEligibleForSri(
 	}
 
 	return false;
+}
+
+/**
+ * Whether a tag's fetch is an ES module fetch: <script type="module"> or
+ * <link rel="modulepreload">. Only these share a request with a module import.
+ */
+export function isModuleTag(element: Element): boolean {
+	const tagName = element.nodeName.toLowerCase();
+	if (tagName === "script") {
+		return getAttrValue(element, "type")?.toLowerCase() === "module";
+	}
+	return (
+		tagName === "link" &&
+		getAttrValue(element, "rel")?.toLowerCase() === "modulepreload"
+	);
 }
 
 /**
@@ -1449,10 +1475,6 @@ export class DynamicImportAnalyzer {
 		OutputBundle,
 		Map<string, string>
 	>();
-	private readonly tagCoveredCache = new WeakMap<
-		OutputBundle,
-		Set<string>
-	>();
 
 	/**
 	 * Constructs a new DynamicImportAnalyzer with the provided logger.
@@ -1546,7 +1568,11 @@ export class DynamicImportAnalyzer {
 	 * analyzeDynamicImports, so identifiers arriving as module IDs, bundle
 	 * keys, or chunk names (Rollup/Rolldown/Vite differ here) all resolve.
 	 */
-	redundantImportMapChunks(bundle: OutputBundle): Set<string> {
+	redundantImportMapChunks(
+		bundle: OutputBundle,
+		base = "/",
+		skipResources: string[] = []
+	): Set<string> {
 		const idToFileMap = this.buildModuleIdMappings(bundle);
 		const chunks = this.extractChunksFromBundle(bundle);
 		const imported = new Set<string>();
@@ -1574,11 +1600,18 @@ export class DynamicImportAnalyzer {
 			}
 		}
 		// Positive tag evidence: a chunk only counts as tag-covered when an
-		// emitted HTML file references it via an SRI-eligible <script>/<link>
-		// (see htmlTagReferencedChunks). Inline-script text, comments, or
-		// embedded JSON mentioning a filename are NOT evidence, and absence of
-		// import edges alone is NOT proof of coverage.
-		const tagReferenced = this.htmlTagReferencedChunks(bundle);
+		// emitted HTML file references it via a tag the SRI pass stamps (see
+		// tagReferencesByPage). Inline-script text, comments, or embedded JSON
+		// mentioning a filename are NOT evidence, and absence of import edges
+		// alone is NOT proof of coverage.
+		const tagReferenced = new Set<string>();
+		for (const refs of this.tagReferencesByPage(
+			bundle,
+			base,
+			skipResources
+		).values()) {
+			refs.forEach((f) => tagReferenced.add(f));
+		}
 		const redundant = new Set<string>();
 		for (const chunk of chunks) {
 			if (imported.has(chunk.fileName)) continue;
@@ -1590,29 +1623,81 @@ export class DynamicImportAnalyzer {
 	}
 
 	/**
-	 * Chunk file names referenced by an SRI-eligible <script>/<link> in any
-	 * emitted HTML file — the tags the SRI pass actually stamps `integrity`
-	 * onto (isEligibleForSri: script[src], link[rel=stylesheet|modulepreload],
-	 * link[rel=preload][as=script|style]). Such a chunk's fetch is already
-	 * protected however the module graph reaches it — including a statically-
-	 * imported chunk that Vite covers with its own <link rel="modulepreload">.
-	 *
-	 * Unlike redundantImportMapChunks this ignores import edges: a tag protects
-	 * the fetch whether or not another chunk also imports the file, so it is the
-	 * accurate "already covered" set for the coverage warning (issue #52), which
-	 * otherwise over-reports. redundantImportMapChunks is the subset of this not
-	 * reached through the module graph. Memoized per bundle — the HTML parse is
-	 * shared with that method.
+	 * Bundle `.js` files whose fetch a stamped HTML tag already protects on
+	 * every page that reaches them (issue #52). Tag protection is per document:
+	 * a chunk one page modulepreloads is still unverified on another page whose
+	 * module graph reaches it without a tag of its own, so each page's graph
+	 * is walked from its tagged chunks and anything reached untagged is
+	 * withdrawn from the credit.
 	 */
-	htmlTagReferencedChunks(bundle: OutputBundle): Set<string> {
-		const cached = this.tagCoveredCache.get(bundle);
-		if (cached) return cached;
+	htmlTagCoveredChunks(
+		bundle: OutputBundle,
+		base = "/",
+		skipResources: string[] = []
+	): Set<string> {
+		const idToFileMap = this.buildModuleIdMappings(bundle);
+		const covered = new Set<string>();
+		const unprotected = new Set<string>();
+		for (const refs of this.tagReferencesByPage(
+			bundle,
+			base,
+			skipResources
+		).values()) {
+			refs.forEach((f) => covered.add(f));
+			const stack = [...refs].filter(
+				(f) => bundle[f]?.type === "chunk"
+			);
+			const seen = new Set(stack);
+			while (stack.length) {
+				const chunk = bundle[stack.pop()!] as OutputChunk;
+				for (const id of [
+					...(chunk.imports || []),
+					...(chunk.dynamicImports || []),
+				]) {
+					// Unresolvable ids were already warned about by
+					// redundantImportMapChunks.
+					const resolved = this.resolveDynamicImport(
+						id,
+						idToFileMap,
+						bundle
+					);
+					if (!resolved || seen.has(resolved)) continue;
+					seen.add(resolved);
+					stack.push(resolved);
+					if (!refs.has(resolved)) unprotected.add(resolved);
+				}
+			}
+		}
+		unprotected.forEach((f) => covered.delete(f));
+		return covered;
+	}
 
-		const tagUrls: string[] = [];
-		for (const [fileName, item] of Object.entries(bundle)) {
+	/**
+	 * Per emitted HTML file, the bundle files its tags will carry integrity
+	 * for. A tag counts only when the SRI pass will stamp it (same eligibility
+	 * and skipResources as processElement) and its URL resolves to a bundle
+	 * file the way processElement looks up a hash — a URL that merely ends
+	 * with a chunk's name is not evidence. Relative hrefs resolve against the
+	 * page's own directory.
+	 *
+	 * A chunk is credited only by a module-shaped tag (<script type="module">,
+	 * <link rel="modulepreload">): a classic <script> or
+	 * <link rel="preload" as="script"> is a separate no-cors fetch the browser
+	 * will not reuse for an ES module import (the issue #53 mismatch). A `.js`
+	 * ASSET is not a module-graph member, so any stamped tag is its actual fetch.
+	 */
+	private tagReferencesByPage(
+		bundle: OutputBundle,
+		base: string,
+		skipResources: string[]
+	): Map<string, Set<string>> {
+		const inBundle = (key: string): boolean =>
+			(key.startsWith("/") ? key.slice(1) : key) in bundle;
+		const pages = new Map<string, Set<string>>();
+		for (const [htmlFile, item] of Object.entries(bundle)) {
 			if (
 				item.type !== "asset" ||
-				!fileName.toLowerCase().endsWith(".html")
+				!htmlFile.toLowerCase().endsWith(".html")
 			) {
 				continue;
 			}
@@ -1626,33 +1711,31 @@ export class DynamicImportAnalyzer {
 				// Malformed source — no tag evidence.
 				continue;
 			}
+			const refs = new Set<string>();
+			pages.set(htmlFile, refs);
+			const dir = path.posix.dirname(htmlFile);
 			const document = parse(html, { sourceCodeLocationInfo: false });
 			for (const el of findElements(document, (node) =>
-				isEligibleForSri(node)
+				isEligibleForSri(node, skipResources)
 			)) {
-				const url = getAttrValue(
-					el,
-					el.nodeName.toLowerCase() === "script" ? "src" : "href"
-				);
 				// Strip query/hash so hashed-URL variants still match.
-				if (url) tagUrls.push(url.split(/[?#]/)[0]);
+				let url = getAttrValue(el, getUrlAttrName(el)!)?.split(
+					/[?#]/
+				)[0];
+				if (!url) continue;
+				if (!isHttpUrl(url) && !url.startsWith("/")) {
+					url = path.posix.join(dir, url);
+				}
+				const key = findPreComputedHashKey(url, inBundle, base);
+				if (!key) continue;
+				const fileName = key.startsWith("/") ? key.slice(1) : key;
+				if (bundle[fileName].type === "chunk" && !isModuleTag(el)) {
+					continue;
+				}
+				refs.add(fileName);
 			}
 		}
-
-		const covered = new Set<string>();
-		for (const chunk of this.extractChunksFromBundle(bundle)) {
-			if (
-				tagUrls.some(
-					(url) =>
-						url === chunk.fileName ||
-						url.endsWith("/" + chunk.fileName)
-				)
-			) {
-				covered.add(chunk.fileName);
-			}
-		}
-		this.tagCoveredCache.set(bundle, covered);
-		return covered;
+		return pages;
 	}
 
 	/**
@@ -1956,9 +2039,6 @@ export class HtmlProcessor {
 			sriByPathname
 		);
 
-		// The chunk set is invariant across the two module-graph consumers
-		// below (preload widening and the import map), so compute it once.
-		const chunkFileNames = collectChunkFileNames(bundle);
 
 		// ========================================================================
 		// DYNAMIC CHUNK PRELOAD INJECTION
@@ -1982,7 +2062,7 @@ export class HtmlProcessor {
 						sriByPathname,
 						this.config.skipResources,
 						redundantImportMapChunks,
-						chunkFileNames
+						collectChunkFileNames(bundle)
 					).map((f) => f.fileName),
 				])
 				: dynamicChunkFiles;
@@ -2010,8 +2090,7 @@ export class HtmlProcessor {
 				processedHtml,
 				sriByPathname,
 				fileName,
-				redundantImportMapChunks,
-				chunkFileNames
+				redundantImportMapChunks
 			);
 		}
 
@@ -2302,15 +2381,13 @@ export class HtmlProcessor {
 		htmlContent: string,
 		sriByPathname: Record<string, string>,
 		fileName: string,
-		redundantImportMapChunks: Set<string>,
-		chunkFileNames: Set<string>
+		redundantImportMapChunks: Set<string>
 	): string {
 		const integrityObject = buildImportIntegrityObject(
 			sriByPathname,
 			this.config.base,
 			this.config.skipResources,
-			redundantImportMapChunks,
-			chunkFileNames
+			redundantImportMapChunks
 		);
 		// Relative base — no valid keys can be produced. The build-level log
 		// in generateBundle reports this once instead of once per HTML file.

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -3784,6 +3784,172 @@ describe("silent-gap detection at stock defaults", () => {
 		);
 	});
 
+	// entry.js statically imports chunk-A.js; each HTML page gets the given head.
+	function staticImportBundle(pages: Record<string, string>): any {
+		const bundle: any = {
+			"assets/entry.js": {
+				type: "chunk",
+				fileName: "assets/entry.js",
+				code: "import './chunk-A.js'; console.log(1)",
+				imports: ["src/chunkA.ts"],
+				dynamicImports: [],
+				modules: { "src/entry.ts": {} },
+				name: "entry",
+				isEntry: true,
+				facadeModuleId: "src/entry.ts",
+			},
+			"assets/chunk-A.js": {
+				type: "chunk",
+				fileName: "assets/chunk-A.js",
+				code: "export const a = 1",
+				imports: [],
+				dynamicImports: [],
+				modules: { "src/chunkA.ts": {} },
+				name: "chunk-A",
+				facadeModuleId: "src/chunkA.ts",
+			},
+		};
+		for (const [file, head] of Object.entries(pages)) {
+			bundle[file] = {
+				type: "asset",
+				source: `<!doctype html><html><head>${head}</head><body></body></html>`,
+			};
+		}
+		return bundle;
+	}
+
+	async function runRelativeBase(bundle: any, options: any = {}) {
+		const plugin = sri({ algorithm: "sha256", ...options }) as any;
+		plugin.configResolved?.({ base: "./", build: { ssr: false } } as any);
+		const mockContext = createMockPluginContext();
+		await plugin.generateBundle.handler.call(mockContext, {}, bundle);
+		return mockContext;
+	}
+
+	it("keeps a .js bundle asset in the import map", async () => {
+		// A `.js` asset (e.g. `import u from './x.js?url'; import(u)`) is a real
+		// module fetch the import map can verify; only preload injection must
+		// skip non-chunks (issue #53).
+		const plugin = sri({ algorithm: "sha256" }) as any;
+		plugin.configResolved?.({ base: "/", build: { ssr: false } } as any);
+		const bundle = staticImportBundle({
+			"index.html": '<script type="module" src="/assets/entry.js"></script>',
+		});
+		bundle["assets/sw-helper.js"] = {
+			type: "asset",
+			fileName: "assets/sw-helper.js",
+			source: "export const sw = 1",
+		};
+		await plugin.generateBundle.handler.call(createMockPluginContext(), {}, bundle);
+		const html = String(bundle["index.html"].source);
+		expect(html).toContain('"/assets/sw-helper.js"');
+		expect(html).not.toMatch(/<link rel="modulepreload" href="\/assets\/sw-helper\.js"/);
+	});
+
+	it("warns about a .js bundle asset no tag or channel covers", async () => {
+		const bundle = staticImportBundle({
+			"index.html":
+				'<script type="module" src="./assets/entry.js"></script>' +
+				'<link rel="modulepreload" href="./assets/chunk-A.js">',
+		});
+		bundle["assets/sw-helper.js"] = {
+			type: "asset",
+			fileName: "assets/sw-helper.js",
+			source: "export const sw = 1",
+		};
+		const ctx = await runRelativeBase(bundle);
+		expect(ctx.warn).toHaveBeenCalledWith(
+			expect.stringContaining("assets/sw-helper.js")
+		);
+	});
+
+	it("credits a classic <script> tag for a .js bundle asset", async () => {
+		// vite-plugin-pwa's registerSW.js is an asset loaded by a classic
+		// script; that tag IS its fetch, so it is covered.
+		const bundle = staticImportBundle({
+			"index.html":
+				'<script type="module" src="./assets/entry.js"></script>' +
+				'<link rel="modulepreload" href="./assets/chunk-A.js">' +
+				'<script src="./registerSW.js"></script>',
+		});
+		bundle["registerSW.js"] = {
+			type: "asset",
+			fileName: "registerSW.js",
+			source: "self.addEventListener('install', () => {})",
+		};
+		const ctx = await runRelativeBase(bundle);
+		expect(ctx.warn).not.toHaveBeenCalledWith(
+			expect.stringContaining("will load without SRI")
+		);
+	});
+
+	it("warns when another page reaches a chunk without its own tag (per-page coverage)", async () => {
+		// admin.html modulepreloads chunk-A; index.html reaches it through
+		// entry.js's static import with no tag of its own.
+		const bundle = staticImportBundle({
+			"admin.html":
+				'<script type="module" src="./assets/entry.js"></script>' +
+				'<link rel="modulepreload" href="./assets/chunk-A.js">',
+			"index.html": '<script type="module" src="./assets/entry.js"></script>',
+		});
+		const ctx = await runRelativeBase(bundle);
+		expect(ctx.warn).toHaveBeenCalledWith(
+			expect.stringContaining("assets/chunk-A.js")
+		);
+	});
+
+	it("resolves relative tag hrefs against the page's own directory", async () => {
+		const bundle = staticImportBundle({
+			"nested/index.html":
+				'<script type="module" src="../assets/entry.js"></script>' +
+				'<link rel="modulepreload" href="../assets/chunk-A.js">',
+		});
+		const ctx = await runRelativeBase(bundle);
+		expect(ctx.warn).not.toHaveBeenCalledWith(
+			expect.stringContaining("will load without SRI")
+		);
+	});
+
+	it("does not credit a tag that skipResources leaves unstamped", async () => {
+		const bundle = staticImportBundle({
+			"index.html":
+				'<script type="module" src="./assets/entry.js"></script>' +
+				'<link rel="modulepreload" id="legacy-boot" href="./assets/chunk-A.js">',
+		});
+		const ctx = await runRelativeBase(bundle, { skipResources: ["legacy-*"] });
+		expect(ctx.warn).toHaveBeenCalledWith(
+			expect.stringContaining("assets/chunk-A.js")
+		);
+	});
+
+	it("does not credit a tag whose URL merely ends with the chunk name", async () => {
+		// The SRI pass resolves this to /v2/assets/chunk-A.js, which is not a
+		// bundle file, so the tag never gets a bundle hash.
+		const bundle = staticImportBundle({
+			"index.html":
+				'<script type="module" src="./assets/entry.js"></script>' +
+				'<link rel="modulepreload" href="https://cdn.other.com/v2/assets/chunk-A.js">',
+		});
+		const ctx = await runRelativeBase(bundle);
+		expect(ctx.warn).toHaveBeenCalledWith(
+			expect.stringContaining("assets/chunk-A.js")
+		);
+	});
+
+	it("does not credit a classic preload tag for a module chunk", async () => {
+		// <link rel="preload" as="script"> is a no-cors fetch the browser will
+		// not reuse for an ES module import — the same mismatch as issue #53.
+		const bundle = staticImportBundle({
+			"index.html":
+				'<script type="module" src="./assets/entry.js"></script>' +
+				'<link rel="preload" as="script" href="./assets/chunk-A.js">',
+		});
+		const ctx = await runRelativeBase(bundle);
+		expect(ctx.warn).toHaveBeenCalledWith(
+			expect.stringContaining("assets/chunk-A.js")
+		);
+	});
+
 	it("goes quiet on a relative-base build once the widened set is enabled", async () => {
 		const plugin = sri({
 			algorithm: "sha256",

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -3950,6 +3950,28 @@ describe("silent-gap detection at stock defaults", () => {
 		);
 	});
 
+	it("credits the import map when a manifest is emitted alongside HTML (issue #52 follow-up)", async () => {
+		// The manifest only decides whether the import() rewrite must stay
+		// active for backend-rendered pages. The emitted HTML still carries
+		// the import map, so its module graph is covered and must not warn.
+		const plugin = sri({ algorithm: "sha256" }) as any;
+		plugin.configResolved?.({ base: "/", build: { ssr: false } } as any);
+		const bundle = relativeBaseGraph();
+		bundle[".vite/manifest.json"] = {
+			type: "asset",
+			source: JSON.stringify({ "src/entry.ts": { file: "assets/entry.js" } }),
+		};
+		const mockContext = createMockPluginContext();
+		await plugin.generateBundle.handler.call(mockContext, {}, bundle);
+
+		expect(String(bundle["index.html"].source)).toContain(
+			'<script type="importmap">'
+		);
+		expect(mockContext.warn).not.toHaveBeenCalledWith(
+			expect.stringContaining("will load without SRI")
+		);
+	});
+
 	it("goes quiet on a relative-base build once the widened set is enabled", async () => {
 		const plugin = sri({
 			algorithm: "sha256",

--- a/test/internal.spec.ts
+++ b/test/internal.spec.ts
@@ -6176,32 +6176,6 @@ describe("collectModuleChunkFiles", () => {
 		expect(files).toEqual([]);
 	});
 
-	it("restricts to genuine Rollup chunks when a chunk set is given", () => {
-		// A `.js` bundle asset (e.g. registerSW.js) must not be treated as a
-		// module chunk (issue #53).
-		const withAsset = {
-			...sriByPathname,
-			"/registerSW.js": "sha256-sw",
-		};
-		const files = collectModuleChunkFiles(
-			withAsset,
-			[],
-			new Set(),
-			new Set(["assets/dep.js", "assets/app.mjs"])
-		).map((f) => f.fileName);
-		expect(files).toEqual(["assets/dep.js", "assets/app.mjs"]);
-	});
-
-	it("matches a query-suffixed chunk pathname against the queryless chunk set", () => {
-		const files = collectModuleChunkFiles(
-			{ "/assets/dep.js?v=abc": "sha256-dep" },
-			[],
-			new Set(),
-			new Set(["assets/dep.js"])
-		).map((f) => f.fileName);
-		expect(files).toEqual(["assets/dep.js?v=abc"]);
-	});
-
 	it("still yields chunks for a relative base that cannot produce import map keys", () => {
 		// modulepreload hrefs resolve against the document URL, so a relative
 		// base is usable here even though it yields no valid import map.

--- a/test/internal.spec.ts
+++ b/test/internal.spec.ts
@@ -8,6 +8,7 @@ import {
 	createLogger,
 	DynamicImportAnalyzer,
 	extractPathnameFromResourceUrl,
+	findPreComputedHashKey,
 	getUrlAttrName,
 	handleGenerateBundleError,
 	HtmlProcessor,
@@ -279,6 +280,38 @@ describe("Internal Utility Functions", () => {
 					new Set(["assets/raw.js"])
 				)
 			).toEqual({});
+		});
+	});
+
+	describe("findPreComputedHashKey", () => {
+		const keys = (...k: string[]) => (key: string) => k.includes(key);
+
+		it("returns the exact pathname when present", () => {
+			expect(
+				findPreComputedHashKey("/assets/a.js", keys("/assets/a.js"), "/")
+			).toBe("/assets/a.js");
+		});
+
+		it("strips the configured base before retrying", () => {
+			expect(
+				findPreComputedHashKey(
+					"/app/assets/a.js",
+					keys("/assets/a.js"),
+					"/app/"
+				)
+			).toBe("/assets/a.js");
+		});
+
+		it("falls through when the base-stripped key is also absent", () => {
+			expect(
+				findPreComputedHashKey("/app/assets/a.js", keys(), "/app/")
+			).toBeUndefined();
+		});
+
+		it("accepts a bare bundle-relative key", () => {
+			expect(
+				findPreComputedHashKey("/assets/a.js", keys("assets/a.js"), "/")
+			).toBe("assets/a.js");
 		});
 	});
 
@@ -1725,6 +1758,69 @@ describe("Processing Classes", () => {
 					expect.stringContaining(
 						'Could not resolve import "src/missing.ts"'
 					)
+				);
+			});
+		});
+
+		describe("htmlTagCoveredChunks", () => {
+			const analyzer = new DynamicImportAnalyzer(createMockBundleLogger());
+
+			function chunk(fileName: string, extra: Record<string, unknown> = {}): any {
+				return {
+					type: "chunk",
+					fileName,
+					code: "",
+					imports: [],
+					dynamicImports: [],
+					modules: {},
+					name: fileName,
+					facadeModuleId: null,
+					...extra,
+				};
+			}
+
+			it("walks a chunk that omits its import arrays", () => {
+				const bundle: any = {
+					"index.html": {
+						type: "asset",
+						source: '<html><head><script type="module" src="/assets/entry.js"></script></head></html>',
+					},
+					"assets/entry.js": {
+						type: "chunk",
+						fileName: "assets/entry.js",
+						code: "",
+						modules: {},
+						name: "entry",
+					},
+				};
+				expect(analyzer.htmlTagCoveredChunks(bundle)).toEqual(
+					new Set(["assets/entry.js"])
+				);
+			});
+
+			it("skips an unresolvable import and revisits a shared chunk only once", () => {
+				const bundle: any = {
+					"index.html": {
+						type: "asset",
+						source:
+							'<html><head><script type="module" src="/assets/entry.js"></script>' +
+							'<link rel="modulepreload" href="/assets/shared.js"></head></html>',
+					},
+					"assets/entry.js": chunk("assets/entry.js", {
+						imports: ["assets/a.js", "assets/b.js", "src/missing.ts"],
+					}),
+					"assets/a.js": chunk("assets/a.js", {
+						imports: ["assets/shared.js"],
+					}),
+					"assets/b.js": chunk("assets/b.js", {
+						imports: ["assets/shared.js"],
+					}),
+					"assets/shared.js": chunk("assets/shared.js"),
+				};
+				// a.js and b.js are reached without tags; shared.js keeps its tag
+				// credit even though two chunks import it.
+				expect(analyzer.htmlTagCoveredChunks(bundle)).toEqual(
+					new Set(["assets/entry.js", "assets/shared.js"])
 				);
 			});
 		});


### PR DESCRIPTION
## Summary

The tag-credit added for #52 (#55) and the chunk filter added for #53 (#54) each silenced the "will load without SRI" warning in cases where the chunk really does ship unverified. This PR closes those gaps, removes the scaffolding the two earlier fixes left behind, brings the new code to full branch coverage, and resolves the #52 reporter's follow-up (warning at the default base).

### Coverage fixes

- **Chunk filter scoped to preload injection.** A `.js` bundle asset stays in the import map (an entry for a `?url` `import()` is real coverage) and in the coverage model. Only modulepreload injection skips non-chunks.
- **Per-page tag evidence.** Each page's module graph is walked from its tagged chunks; a chunk reached without a tag on that page is withdrawn from the credit. A chunk modulepreloaded on `admin.html` no longer hides a gap on `index.html`.
- **Tags resolved like the SRI pass.** The hash-key lookup in `processElement` is extracted as `findPreComputedHashKey` and reused for crediting, replacing the `endsWith` suffix heuristic. Relative hrefs resolve against the page's own directory.
- **`skipResources` honoured.** A tag the SRI pass leaves unstamped earns no credit.
- **Module-shaped tags only for chunks.** A chunk is credited only by `<script type="module">` or `<link rel="modulepreload">`; a classic `<script>` or `<link rel="preload" as="script">` is a separate no-cors fetch. A `.js` asset is credited by any stamped tag, since that tag is its actual fetch (keeps vite-plugin-pwa's `registerSW.js` quiet at a relative base).

### #52 follow-up: warning at the default base

The reporter saw the warning with `base` untouched. Reproduced on Vite 8.1.0: at base `/` the warning fires only when a `manifest.json` asset is in the bundle (e.g. `build.manifest: true`), and the emitted HTML still carries the import map.

Root cause: the warning reused `importMapCapable`, whose `!hasManifestFiles` term exists to keep the `import()` rewrite active for backend-rendered pages. It says nothing about the emitted HTML, which the coverage model describes. The warning now credits the import map whenever the map is actually injected. `importMapCapable` and the rewrite decision are unchanged.

### Cleanup

- `collectModuleChunkFiles` loses its optional `chunkFileNames` parameter and the query-strip that only served it. The one caller that wants chunks only (preload widening) filters on the bundle item type inline, so `collectChunkFileNames` and its per-HTML-file recomputation are gone and every other caller is consistent by construction. The pin-divergence check in `injectImportMap` can no longer diverge from the other callers.
- The coverage block passes the tag-covered set straight to `collectModuleChunkFiles` as the exclude set instead of excluding the redundant subset first and unioning the superset in afterwards.
- The per-bundle WeakMap memo on the tag scan is removed. It cached a parse of HTML sources the plugin overwrites later in the same pass, so it was only correct under an unenforced call order.
- Four branches in the new code could never take their second arm and were deleted: the `/`-prefixed normalized-path retry (duplicated the exact-pathname check), the null guard on an eligible tag's URL attribute, the conditional slash-strip on a tag-scan hit, and the tag check on a chunk newly reached in the page walk (`seen` is seeded with every tagged chunk).

## Tradeoff

Restoring `.js` assets to the coverage model means an untagged asset (e.g. a worker bundle) is warned about at a relative base again, as in 1.7.3. Accurate, but noisier than post-#54.

## Tests

- Nine new integration cases under "silent-gap detection at stock defaults". Seven failed before their fix; two guard the asset-credit and nested-page rules.
- Unit tests for `findPreComputedHashKey` (exact hit, base strip, base-strip miss, bare key) and `htmlTagCoveredChunks` (chunk without import arrays; unresolvable import plus a diamond graph).
- Two unit tests that exercised a query-suffixed key shape `sriByPathname` never produces were removed with the parameter they tested.
- Verified end to end with a real `vite build` on Vite 8.1.0: stock defaults, `build.manifest: true`, and `build.manifest: true` + `preloadDynamicChunks: false` (rewrite still active).

- vitest: 507 passed
- build, lint, coverage thresholds: pass
- no uncovered branch arms remain in the changed regions

https://claude.ai/code/session_01KKrtPgK6b5eW6E2qcENEpX
